### PR TITLE
Update setup instructions for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,17 @@ These values are read by the front-end to initiate the login process.
 
 ## Running in Codex
 
-If you encounter a message like "Codex couldn't run certain commands due to environment limitations," make sure the container installs dependencies before running tests or other commands. A simple `setup.sh` script can be used:
+If you encounter a message like "Codex couldn't run certain commands due to environment limitations," make sure the container installs dependencies before running tests or other commands. A simple `setup.sh` script can be used. The script uses `npm ci` when a `package-lock.json` file is present, falling back to `npm install` otherwise:
 
 ```bash
 #!/bin/bash
 set -e
-npm install
+
+if [ -f package-lock.json ]; then
+  npm ci
+else
+  npm install
+fi
 ```
 
 Run this script manually or in your CI pipeline so the environment has the required packages when Codex executes your commands.

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,11 @@ set -e
 
 # Install dependencies required for building and testing
 if command -v npm >/dev/null 2>&1; then
-  npm install
+  if [ -f package-lock.json ]; then
+    npm ci
+  else
+    npm install
+  fi
 else
   echo "npm not found. Please install Node.js before running this script." >&2
   exit 1


### PR DESCRIPTION
## Summary
- clarify the Codex setup instructions in README
- enhance `setup.sh` to use `npm ci` when a lockfile exists

## Testing
- `npm test`
- `bash verify-tailwind-postcss-autoprefixer.sh`

------
https://chatgpt.com/codex/tasks/task_b_684f08406b408328823dc04f538230e6