### PR TITLE
Add signup Lambda handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ These values are read by the front-end to initiate the login process.
 *   See [docs/artist-dashboard-plan.md](docs/artist-dashboard-plan.md) for a
     proposed Artist Dashboard backend and adoption strategy.
 
+
+## Signup Lambda Function
+The backend includes a sample AWS Lambda handler at `backend/lambda/signupHandler.js` which emails signup details via SES. Deploy it using the CloudFormation template at `backend/cloudformation/signupLambda.yml` or wire it up with Amplify.
 ## Running in Codex
 
 If you encounter a message like "Codex couldn't run certain commands due to environment limitations," make sure the container installs dependencies before running tests or other commands. A simple `setup.sh` script can be used. The script uses `npm ci` when a `package-lock.json` file is present, falling back to `npm install` otherwise:

--- a/backend/cloudformation/signupLambda.yml
+++ b/backend/cloudformation/signupLambda.yml
@@ -1,0 +1,44 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  SignupFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: signupHandler.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt SignupFunctionRole.Arn
+      Code:
+        ZipFile: |
+          const AWS = require('aws-sdk');
+          const ses = new AWS.SES({ region: 'us-east-1' });
+          exports.handler = async (event) => {
+            const body = JSON.parse(event.body);
+            const { name, email, company, role, message, type } = body;
+            const params = {
+              Destination: { ToAddresses: ['ops@decodedmusic.com'] },
+              Message: {
+                Body: { Text: { Data: `New Signup (${type}):\nName: ${name}\nEmail: ${email}\nCompany: ${company}\nRole: ${role}\nMessage: ${message}` } },
+                Subject: { Data: `New Signup – ${type === 'artist' ? 'Artist' : 'Licensing'} Inquiry` },
+              },
+              Source: 'ops@decodedmusic.com',
+            };
+            await ses.sendEmail(params).promise();
+            return { statusCode: 200, body: 'Submitted' };
+          };
+  SignupFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: allowSES
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: ses:SendEmail
+                Resource: '*'

--- a/backend/lambda/signupHandler.js
+++ b/backend/lambda/signupHandler.js
@@ -1,0 +1,37 @@
+const AWS = require("aws-sdk");
+const ses = new AWS.SES({ region: "us-east-1" });
+
+exports.handler = async (event) => {
+  const body = JSON.parse(event.body);
+
+  const { name, email, company, role, message, type } = body;
+
+  const emailParams = {
+    Destination: { ToAddresses: ["ops@decodedmusic.com"] },
+    Message: {
+      Body: {
+        Text: {
+          Data: `New Signup (${type}):\nName: ${name}\nEmail: ${email}\nCompany: ${company}\nRole: ${role}\nMessage: ${message}`,
+        },
+      },
+      Subject: { Data: `\uD83C\uDFB6 New Signup – ${type === "artist" ? "Artist" : "Licensing"} Inquiry` },
+    },
+    Source: "ops@decodedmusic.com",
+  };
+
+  try {
+    await ses.sendEmail(emailParams).promise();
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: "Submitted successfully" }),
+      headers: { "Access-Control-Allow-Origin": "*" },
+    };
+  } catch (error) {
+    console.error("Signup Error:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: "Submission failed" }),
+      headers: { "Access-Control-Allow-Origin": "*" },
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add backend/lambda signupHandler.js for SES signups
- include CloudFormation snippet to deploy the Lambda
- document new backend handler in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684f199507c08328a30f24330e30bd06