### PR TITLE
Add Signup API CloudFormation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ These values are read by the front-end to initiate the login process.
 
 ## Signup Lambda Function
 The backend includes a sample AWS Lambda handler at `backend/lambda/signupHandler.js` which emails signup details via SES. Deploy it using the CloudFormation template at `backend/cloudformation/signupLambda.yml` or wire it up with Amplify.
+The API Gateway and Lambda permission configuration lives in `backend/cloudformation/signupApi.yml`. Deploy this CloudFormation stack after uploading `lambdas/signup-handler.zip` to S3 to expose a `/signup` endpoint.
+
 ## Running in Codex
 
 If you encounter a message like "Codex couldn't run certain commands due to environment limitations," make sure the container installs dependencies before running tests or other commands. A simple `setup.sh` script can be used. The script uses `npm ci` when a `package-lock.json` file is present, falling back to `npm install` otherwise:

--- a/backend/cloudformation/signupApi.yml
+++ b/backend/cloudformation/signupApi.yml
@@ -1,0 +1,46 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  SignupLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: DecodedSignupHandler
+      Runtime: nodejs18.x
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Handler: index.handler
+      Code:
+        S3Bucket: decodedmusic.com
+        S3Key: lambdas/signup-handler.zip
+
+  SignupApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: DecodedSignupAPI
+
+  SignupResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt SignupApi.RootResourceId
+      PathPart: signup
+      RestApiId: !Ref SignupApi
+
+  SignupPostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: POST
+      ResourceId: !Ref SignupResource
+      RestApiId: !Ref SignupApi
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub
+          - arn:aws:apigateway:${Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
+          - { Region: !Ref "AWS::Region", LambdaArn: !GetAtt SignupLambdaFunction.Arn }
+
+  LambdaPermissionForSignup:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt SignupLambdaFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${SignupApi}/*/POST/signup


### PR DESCRIPTION
## Summary
- create CloudFormation template for API Gateway and permissions
- document how to deploy signup API

## Testing
- `./setup.sh`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684f1b684e6883289d7ca3f5d2fc0189