### PR TITLE
Implement mini accounting module

### DIFF
--- a/backend/lambda/expenseHandler.js
+++ b/backend/lambda/expenseHandler.js
@@ -1,0 +1,55 @@
+const { DynamoDBClient, PutItemCommand, QueryCommand, ScanCommand } = require('@aws-sdk/client-dynamodb');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.EXPENSE_TABLE || 'ExpenseLog';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    if (event.httpMethod === 'POST') {
+      const body = JSON.parse(event.body || '{}');
+      const item = {
+        artist_id: { S: body.artist_id },
+        vendor: { S: body.vendor },
+        type: { S: body.type },
+        amount_cents: { N: String(body.amount_cents || 0) },
+        date: { S: body.date || new Date().toISOString().slice(0,10) },
+        campaign: { S: body.campaign || '' },
+        note: { S: body.note || '' }
+      };
+      await ddb.send(new PutItemCommand({ TableName: TABLE, Item: item }));
+      return response(200, { message: 'Expense recorded' });
+    }
+    if (event.httpMethod === 'GET') {
+      const qs = event.queryStringParameters || {};
+      if (qs.artist_id) {
+        const data = await ddb.send(new QueryCommand({
+          TableName: TABLE,
+          KeyConditionExpression: 'artist_id = :a',
+          ExpressionAttributeValues: { ':a': { S: qs.artist_id } }
+        }));
+        return response(200, (data.Items || []).map(cleanItem));
+      } else {
+        const data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
+        return response(200, (data.Items || []).map(cleanItem));
+      }
+    }
+    return response(405, { message: 'Method Not Allowed' });
+  } catch (err) {
+    console.error('expenseHandler error', err);
+    return response(500, { message: 'Internal Server Error' });
+  }
+};
+
+function response(statusCode, body) {
+  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+}
+
+function cleanItem(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    const val = v.S ?? (v.N ? Number(v.N) : undefined);
+    obj[k] = val;
+  }
+  return obj;
+}

--- a/backend/lambda/exportAccountingHandler.js
+++ b/backend/lambda/exportAccountingHandler.js
@@ -1,0 +1,74 @@
+const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const REV_TABLE = process.env.REVENUE_TABLE || 'RevenueLog';
+const EXP_TABLE = process.env.EXPENSE_TABLE || 'ExpenseLog';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const qs = event.queryStringParameters || {};
+    const artistId = qs.artist_id;
+    if (!artistId) return response(400, { message: 'artist_id required' });
+
+    const [revData, expData] = await Promise.all([
+      ddb.send(new QueryCommand({
+        TableName: REV_TABLE,
+        KeyConditionExpression: 'artist_id = :a',
+        ExpressionAttributeValues: { ':a': { S: artistId } }
+      })),
+      ddb.send(new QueryCommand({
+        TableName: EXP_TABLE,
+        KeyConditionExpression: 'artist_id = :a',
+        ExpressionAttributeValues: { ':a': { S: artistId } }
+      }))
+    ]);
+
+    const revenue = (revData.Items || []).map(cleanItem);
+    const expenses = (expData.Items || []).map(cleanItem);
+
+    const totalRevenue = revenue.reduce((s, r) => s + r.revenue_cents, 0);
+    const totalExpenses = expenses.reduce((s, e) => s + e.amount_cents, 0);
+    const net = totalRevenue - totalExpenses;
+    const unpaid = revenue.filter(r => r.status !== 'Paid').reduce((s, r) => s + r.revenue_cents, 0);
+
+    const rows = ['Type,Title/Vendor,Platform/Category,Amount (USD),Date,Status'];
+    for (const r of revenue) {
+      rows.push(`Revenue,${r.title},${r.platform},$${(r.revenue_cents/100).toFixed(2)},${r.period},${r.status}`);
+    }
+    for (const e of expenses) {
+      rows.push(`Expense,${e.vendor},${e.type},$${(e.amount_cents/100).toFixed(2)},${e.date},-`);
+    }
+    rows.push('Totals,,,');
+    rows.push(`Net,$${(net/100).toFixed(2)},Total Revenue,$${(totalRevenue/100).toFixed(2)}`);
+    rows.push(`Total Expenses,$${(totalExpenses/100).toFixed(2)},Unpaid Revenue,$${(unpaid/100).toFixed(2)}`);
+
+    const csv = rows.join('\n');
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'text/csv',
+        'Content-Disposition': 'attachment; filename="accounting.csv"'
+      },
+      body: csv
+    };
+  } catch (err) {
+    console.error('export accounting error', err);
+    return response(500, { message: 'Internal Server Error' });
+  }
+};
+
+function response(statusCode, body) {
+  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+}
+
+function cleanItem(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    const val = v.S ?? (v.N ? Number(v.N) : undefined);
+    obj[k] = val;
+  }
+  return obj;
+}

--- a/backend/lambda/payoutScheduler.js
+++ b/backend/lambda/payoutScheduler.js
@@ -1,0 +1,29 @@
+const { DynamoDBClient, ScanCommand, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.REVENUE_TABLE || 'RevenueLog';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async () => {
+  const threshold = new Date();
+  threshold.setMonth(threshold.getMonth() - 3);
+  const periodCutoff = threshold.toISOString().slice(0,7);
+  const scanParams = new ScanCommand({
+    TableName: TABLE,
+    FilterExpression: '#p <= :m AND #s <> :paid',
+    ExpressionAttributeNames: { '#p': 'period', '#s': 'status' },
+    ExpressionAttributeValues: { ':m': { S: periodCutoff }, ':paid': { S: 'Paid' } }
+  });
+  const data = await ddb.send(scanParams);
+  const items = data.Items || [];
+  for (const item of items) {
+    await ddb.send(new UpdateItemCommand({
+      TableName: TABLE,
+      Key: { artist_id: item.artist_id, track_id: item.track_id },
+      UpdateExpression: 'SET #s = :p',
+      ExpressionAttributeNames: { '#s': 'status' },
+      ExpressionAttributeValues: { ':p': { S: 'Paid' } }
+    }));
+  }
+  return { statusCode: 200, body: JSON.stringify({ updated: items.length }) };
+};

--- a/backend/lambda/revenueHandler.js
+++ b/backend/lambda/revenueHandler.js
@@ -1,0 +1,57 @@
+const { DynamoDBClient, PutItemCommand, QueryCommand, ScanCommand } = require('@aws-sdk/client-dynamodb');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.REVENUE_TABLE || 'RevenueLog';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    if (event.httpMethod === 'POST') {
+      const body = JSON.parse(event.body || '{}');
+      const item = {
+        artist_id: { S: body.artist_id },
+        track_id: { S: body.track_id },
+        title: { S: body.title },
+        type: { S: body.type },
+        platform: { S: body.platform },
+        revenue_cents: { N: String(body.revenue_cents || 0) },
+        period: { S: body.period || new Date().toISOString().slice(0,7) },
+        status: { S: body.status || 'Pending' },
+        expected_payout_date: { S: body.expected_payout_date || '' }
+      };
+      await ddb.send(new PutItemCommand({ TableName: TABLE, Item: item }));
+      return response(200, { message: 'Revenue recorded' });
+    }
+    if (event.httpMethod === 'GET') {
+      const qs = event.queryStringParameters || {};
+      if (qs.artist_id) {
+        const data = await ddb.send(new QueryCommand({
+          TableName: TABLE,
+          KeyConditionExpression: 'artist_id = :a',
+          ExpressionAttributeValues: { ':a': { S: qs.artist_id } }
+        }));
+        return response(200, (data.Items || []).map(cleanItem));
+      } else {
+        const data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
+        return response(200, (data.Items || []).map(cleanItem));
+      }
+    }
+    return response(405, { message: 'Method Not Allowed' });
+  } catch (err) {
+    console.error('revenueHandler error', err);
+    return response(500, { message: 'Internal Server Error' });
+  }
+};
+
+function response(statusCode, body) {
+  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+}
+
+function cleanItem(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    const val = v.S ?? (v.N ? Number(v.N) : undefined);
+    obj[k] = val;
+  }
+  return obj;
+}

--- a/docs/accounting-module.md
+++ b/docs/accounting-module.md
@@ -1,0 +1,57 @@
+# Mini Accounting Module (v1)
+
+This module tracks revenue and expenses for each artist and provides a simple dashboard export.
+
+## Dashboard View Components
+
+| Section | Fields |
+| --- | --- |
+| Revenue | Track title, type (single/album/sync), platform, est. revenue, payout status, payout date |
+| Expenses | Vendor, type (marketing, ASCAP, distribution), amount, date, campaign |
+| Summary Totals | Net earnings, total revenue, total expenses, unpaid revenue |
+
+## DynamoDB Tables
+
+### RevenueLog
+```json
+{
+  "artist_id": "RDV",
+  "track_id": "abc123",
+  "title": "Fireproof",
+  "type": "single",
+  "platform": "Spotify",
+  "revenue_cents": 4820,
+  "period": "2025-02",
+  "status": "Pending",
+  "expected_payout_date": "2025-05-01"
+}
+```
+
+### ExpenseLog
+```json
+{
+  "artist_id": "RDV",
+  "vendor": "Meta",
+  "type": "marketing",
+  "amount_cents": 599,
+  "date": "2025-02-15",
+  "campaign": "fireproof_ig_launch",
+  "note": "Instagram ads for single release"
+}
+```
+
+## Export Feature
+A Lambda function (`GET /api/dashboard/accounting/export`) queries both tables, combines the records into a CSV and returns the file for download.
+
+Sample CSV rows:
+```
+Type,Title/Vendor,Platform/Category,Amount (USD),Date,Status
+Revenue,Fireproof,Spotify,$48.20,2025-02,Paid
+Expense,Meta,Marketing,$5.99,2025-02,-
+```
+
+## Lagged Payout Logic
+A scheduled Lambda runs monthly via EventBridge. Entries with a period three months old are automatically marked as `Paid` to simulate real royalty payouts.
+
+## Frontend Stub
+The React frontend now has an **Accounting** tab which lists placeholder charts and a CSV download button. In a production build it would call the API routes above and visualize monthly cash flow.

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import ArtistDashboard from './pages/ArtistDashboard';
 import MarketingHub from './pages/MarketingHub';
+import Accounting from './pages/Accounting';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
       <Route path="/" element={<LandingPage />} />
       <Route path="/dashboard" element={<ArtistDashboard />} />
       <Route path="/marketing" element={<MarketingHub />} />
+      <Route path="/accounting" element={<Accounting />} />
     </Routes>
   );
 }

--- a/src/pages/Accounting.jsx
+++ b/src/pages/Accounting.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function Accounting() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Accounting</h1>
+      <div style={{ margin: '1rem 0' }}>
+        <button style={{ padding: '0.5rem 1rem', background: '#32C1ED', color: '#fff', border: 'none', borderRadius: 4 }}>
+          Download CSV
+        </button>
+      </div>
+      <div style={{ border: '1px solid #ccc', height: 200, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <svg width="300" height="150">
+          <rect x="10" y="50" width="40" height="80" fill="#32C1ED" />
+          <rect x="70" y="30" width="40" height="100" fill="#32C1ED" />
+          <rect x="130" y="70" width="40" height="60" fill="#32C1ED" />
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+export default Accounting;


### PR DESCRIPTION
## Summary
- add DynamoDB lambda handlers for revenue and expenses
- create CSV export lambda and payout scheduler
- document the accounting module design
- add Accounting tab to the React app
- include a placeholder chart

## Testing
- `bash setup.sh`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684f3154e8748328a9b2b4ad7bbe153e