### PR TITLE
Implement subscription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ These values are read by the front-end to initiate the login process.
     for an overview of Spotify OAuth and the Cognito user pool.
 *   See [docs/catalog-upload-pipeline.md](docs/catalog-upload-pipeline.md)
     for the catalog upload and metadata extraction pipeline.
+*   See [docs/subscription-system.md](docs/subscription-system.md)
+    for the artist subscription workflow and company revenue reporting.
 
 
 ## Signup Lambda Function

--- a/backend/lambda/subscriptionReportHandler.js
+++ b/backend/lambda/subscriptionReportHandler.js
@@ -1,0 +1,43 @@
+const { DynamoDBClient, ScanCommand } = require('@aws-sdk/client-dynamodb');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.SUB_TABLE || 'ArtistSubscriptions';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async () => {
+  try {
+    const data = await ddb.send(new ScanCommand({ TableName: TABLE }));
+    const items = data.Items || [];
+    const records = items.map(clean);
+    const totalSubscribers = records.filter(r => r.active).length;
+    const monthlyRevenue = totalSubscribers * 99;
+    const avgRetention = calcRetention(records);
+    return {
+      statusCode: 200,
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      body: JSON.stringify({ totalSubscribers, monthlyRevenue, avgRetention })
+    };
+  } catch (err) {
+    console.error('report error', err);
+    return { statusCode: 500, body: JSON.stringify({ message: 'error' }) };
+  }
+};
+
+function clean(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    obj[k] = v.S ?? v.N ?? v.BOOL;
+  }
+  return obj;
+}
+
+function calcRetention(records) {
+  const months = records.map(r => {
+    if (!r.subscribed_since) return 0;
+    const diff = Date.now() - new Date(r.subscribed_since).getTime();
+    return diff / (1000 * 60 * 60 * 24 * 30);
+  }).filter(n => n > 0);
+  if (!months.length) return 0;
+  const avg = months.reduce((a,b) => a + b, 0) / months.length;
+  return Number(avg.toFixed(1));
+}

--- a/backend/lambda/subscriptionWebhookHandler.js
+++ b/backend/lambda/subscriptionWebhookHandler.js
@@ -1,0 +1,59 @@
+const { DynamoDBClient, PutItemCommand, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
+const { SESClient, SendEmailCommand } = require('@aws-sdk/client-ses');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.SUB_TABLE || 'ArtistSubscriptions';
+const ddb = new DynamoDBClient({ region: REGION });
+const ses = new SESClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const type = body.type || '';
+    const data = body.data?.object || {};
+
+    if (type === 'invoice.paid') {
+      const item = {
+        artist_id: { S: data.metadata.artist_id },
+        email: { S: data.customer_email || '' },
+        subscribed_since: { S: new Date(data.created * 1000).toISOString().slice(0,10) },
+        next_billing_date: { S: new Date(data.period_end * 1000).toISOString().slice(0,10) },
+        active: { BOOL: true },
+        subscription_id: { S: data.subscription || '' }
+      };
+      await ddb.send(new PutItemCommand({ TableName: TABLE, Item: item }));
+    }
+
+    if (type === 'invoice.payment_failed') {
+      await ddb.send(new UpdateItemCommand({
+        TableName: TABLE,
+        Key: { artist_id: { S: data.metadata.artist_id } },
+        UpdateExpression: 'SET active = :f',
+        ExpressionAttributeValues: { ':f': { BOOL: false } }
+      }));
+      await sendFailureEmail(data.customer_email);
+    }
+
+    return { statusCode: 200, body: JSON.stringify({ message: 'ok' }) };
+  } catch (err) {
+    console.error('webhook error', err);
+    return { statusCode: 500, body: JSON.stringify({ message: 'error' }) };
+  }
+};
+
+async function sendFailureEmail(to) {
+  if (!to) return;
+  const params = {
+    Destination: { ToAddresses: [to] },
+    Message: {
+      Body: { Text: { Data: 'Your Decoded Music subscription payment failed. Please update your billing info.' } },
+      Subject: { Data: 'Payment Failed' }
+    },
+    Source: 'no-reply@decodedmusic.com'
+  };
+  try {
+    await ses.send(new SendEmailCommand(params));
+  } catch (err) {
+    console.error('email send error', err);
+  }
+}

--- a/docs/subscription-system.md
+++ b/docs/subscription-system.md
@@ -1,0 +1,37 @@
+# Artist Access & Subscription System
+
+This module governs dashboard access for artists and tracks recurring subscription revenue.
+
+## Access Control
+- Artists must exist in Cognito user pool `5fxmkd` to reach any `/api/dashboard/*` endpoint.
+- Each artist record stores `artist_id`, `email` and `active_subscriber` status.
+
+## DynamoDB – `ArtistSubscriptions`
+```json
+{
+  "artist_id": "RDV",
+  "email": "artist@example.com",
+  "subscribed_since": "2025-06-01",
+  "next_billing_date": "2025-07-01",
+  "active": true,
+  "subscription_id": "sub_abc123"
+}
+```
+
+## Stripe Webhook Lambda
+`subscriptionWebhookHandler` listens for Stripe events:
+- `invoice.paid` → create/update the table entry and set `active` to **true**.
+- `invoice.payment_failed` → mark the subscription **inactive** and send an email reminder via SES.
+
+Webhook URL example: `/api/subscription/webhook`.
+
+## Company Subscription Report Lambda
+`subscriptionReportHandler` scans the table and returns company level metrics:
+- `totalSubscribers` – count of active records.
+- `monthlyRevenue` – `$99 * totalSubscribers`.
+- `avgRetention` – average months since `subscribed_since` among all records.
+
+This powers the internal **Decoded Music Paying Subscribers** dashboard.
+
+## Future YouTube Integration
+A placeholder table `CompanyYouTubeStats` stores channel stats for future AdSense hooks and community analysis.


### PR DESCRIPTION
## Summary
- create docs on artist subscription workflow
- add Lambda for Stripe webhook handling
- add Lambda for company subscription reporting
- link new documentation in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684f36516bb883288af0dd8de8185416