### PR TITLE
Update signup API endpoint

### DIFF
--- a/src/components/signup/SignupForm.jsx
+++ b/src/components/signup/SignupForm.jsx
@@ -18,8 +18,8 @@ export default function SignupForm({ type }) {
   async function handleSubmit(e) {
     e.preventDefault();
     setStatus("Submitting...");
-    // Replace with your actual API Gateway endpoint
-    const response = await fetch("https://your-api-id.execute-api.region.amazonaws.com/prod/signup", {
+    // Submit form data to the UseCaseManagementAPI Gateway endpoint
+    const response = await fetch("https://n64vgs0he0.execute-api.us-east-1.amazonaws.com/prod/signup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(form),


### PR DESCRIPTION
## Summary
- use the actual AWS API Gateway endpoint for sign up

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f3c4ab98c8328a8c14dcaa6453739