### PR TITLE
Add DecodedMusicBackend stack details

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ aws cloudformation deploy \
 The `EnvName` parameter defaults to `prod`, but you can override it to create
 multiple environments.
 
+### DecodedMusicBackend Stack
+
+Codex automation uses a backend CloudFormation stack named `DecodedMusicBackend`.
+It provisions a Lambda function, API Gateway and DynamoDB table. Deploy it with:
+
+```bash
+aws cloudformation deploy \
+  --template-file backend/cloudformation/decodedMusicBackend.yaml \
+  --stack-name DecodedMusicBackend \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+After deployment the CloudFormation console should show a `CREATE_COMPLETE` status.
+
 ### Catalog API
 
 Deploy `cloudformation/catalog-api.yml` to expose a simple REST API for listing

--- a/backend/cloudformation/decodedMusicBackend.yaml
+++ b/backend/cloudformation/decodedMusicBackend.yaml
@@ -1,0 +1,89 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Backend stack for Decoded Music using Lambda, API Gateway and DynamoDB
+Resources:
+  BackendTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: DecodedMusicItems
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+  BackendLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: dynamodb-access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:Scan
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+  BackendLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: DecodedMusicBackendHandler
+      Runtime: nodejs18.x
+      Handler: index.handler
+      Role: !GetAtt BackendLambdaRole.Arn
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref BackendTable
+      Code:
+        ZipFile: |
+          exports.handler = async (event) => {
+            console.log('request:', JSON.stringify(event));
+            return { statusCode: 200, body: 'ok' };
+          };
+  ApiGateway:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: DecodedMusicBackendApi
+  ApiResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt ApiGateway.RootResourceId
+      PathPart: backend
+      RestApiId: !Ref ApiGateway
+  ApiMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      AuthorizationType: NONE
+      HttpMethod: ANY
+      ResourceId: !Ref ApiResource
+      RestApiId: !Ref ApiGateway
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${BackendLambda.Arn}/invocations'
+  LambdaPermissionApi:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref BackendLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGateway}/*/*/backend'
+Outputs:
+  ApiUrl:
+    Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/prod/backend'
+    Description: Endpoint for the DecodedMusicBackend API

--- a/docs/decodedmusic-backend-stack.md
+++ b/docs/decodedmusic-backend-stack.md
@@ -1,0 +1,16 @@
+# DecodedMusicBackend CloudFormation Stack
+
+This stack is used by Codex and GitHub automation to provision the core backend services.
+
+- **Stack Name:** `DecodedMusicBackend`
+- **Resources:** AWS Lambda, API Gateway and a DynamoDB table
+- After deployment the CloudFormation console should show a status of `CREATE_COMPLETE`.
+
+Deploy with:
+
+```bash
+aws cloudformation deploy \
+  --template-file backend/cloudformation/decodedMusicBackend.yaml \
+  --stack-name DecodedMusicBackend \
+  --capabilities CAPABILITY_NAMED_IAM
+```


### PR DESCRIPTION
## Summary
- create CloudFormation template `decodedMusicBackend.yaml`
- add a documentation page describing the stack
- document how to deploy the stack in the README

## Testing
- `npm ci`
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_684f3fe4f5a8832899f5de45d632fa98