### PR TITLE
Add region flag to deploy docs and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ It provisions a Lambda function, API Gateway and DynamoDB table. Deploy it with:
 aws cloudformation deploy \
   --template-file backend/cloudformation/decodedMusicBackend.yaml \
   --stack-name DecodedMusicBackend \
+  --region eu-central-1 \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 

--- a/automate-cloudshell-deploy.sh
+++ b/automate-cloudshell-deploy.sh
@@ -2,6 +2,9 @@
 # automate-cloudshell-deploy.sh
 # Automates syncing the repo with AWS Amplify from an AWS CloudShell session.
 
+# Set region for all Amplify commands
+export AWS_REGION=eu-central-1
+
 # 1. Set your repo and Amplify identifiers
 : "${REPO:?Set REPO to your GitHub repository URL}"       # e.g. https://github.com/yourname/yourrepo.git
 : "${AMPLIFY_APP_ID:?Set AMPLIFY_APP_ID to your Amplify app ID}"
@@ -30,12 +33,13 @@ npm install -g @aws-amplify/cli
 amplify pull \
   --appId "$AMPLIFY_APP_ID" \
   --envName "$AMPLIFY_ENV_NAME" \
+  --region eu-central-1 \
   --yes
 
 # 6. Push backend changes
-amplify push --yes
+amplify push --region eu-central-1 --yes
 
 # 7. Build front-end and publish
 cd decodedmusic-frontend
 npm run build
-amplify publish --yes
+amplify publish --region eu-central-1 --yes

--- a/docs/decodedmusic-backend-stack.md
+++ b/docs/decodedmusic-backend-stack.md
@@ -12,6 +12,7 @@ Deploy with:
 aws cloudformation deploy \
   --template-file backend/cloudformation/decodedMusicBackend.yaml \
   --stack-name DecodedMusicBackend \
+  --region eu-central-1 \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 


### PR DESCRIPTION
## Summary
- ensure deploy commands specify `--region eu-central-1`
- set region in CloudShell deployment script

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684f463299ec83289e0d2ca79022f34a