### PR TITLE
Add pitch handler lambda and CloudFormation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
+## Pitch Lambda Function
+The sync licensing pitch handler at `backend/lambdas/pitchHandler/index.js` sends templated emails via SES.
+Package and upload the code to S3:
+
+```bash
+cd backend/lambdas/pitchHandler
+zip -r pitchHandler.zip .
+aws s3 cp pitchHandler.zip s3://decodedmusic-lambda-code/
+```
+
+Deploy the resources defined in `backend/cloudformation/decodedMusicBackend.yaml` to expose a `/api/pitch` endpoint:
+
+```bash
+aws cloudformation deploy \
+  --template-file backend/cloudformation/decodedMusicBackend.yaml \
+  --stack-name DecodedMusicBackend \
+  --region eu-central-1 \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
 ## Running in Codex
 
 If you encounter a message like "Codex couldn't run certain commands due to environment limitations," make sure the container installs dependencies before running tests or other commands. A simple `setup.sh` script can be used. The script uses `npm ci` when a `package-lock.json` file is present, falling back to `npm install` otherwise:

--- a/backend/cloudformation/decodedMusicBackend.yaml
+++ b/backend/cloudformation/decodedMusicBackend.yaml
@@ -83,7 +83,74 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGateway}/*/*/backend'
+
+  PitchLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: PitchHandler
+      Handler: index.handler
+      Role: !GetAtt PitchLambdaRole.Arn
+      Runtime: nodejs18.x
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: pitchHandler.zip
+
+  PitchLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: PitchLambdaExecutionRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: AllowSESSend
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ses:SendEmail
+                Resource: "*"
+
+  PitchApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: PitchAPI
+
+  PitchResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt PitchApi.RootResourceId
+      PathPart: pitch
+      RestApiId: !Ref PitchApi
+
+  PitchMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: POST
+      ResourceId: !Ref PitchResource
+      RestApiId: !Ref PitchApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PitchLambda.Arn}/invocations
+
+  PitchLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PitchLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PitchApi}/*/POST/pitch
 Outputs:
   ApiUrl:
     Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/prod/backend'
     Description: Endpoint for the DecodedMusicBackend API
+  PitchApiUrl:
+    Value: !Sub 'https://${PitchApi}.execute-api.${AWS::Region}.amazonaws.com/prod/pitch'
+    Description: Endpoint for sync licensing pitches

--- a/backend/lambdas/pitchHandler/index.js
+++ b/backend/lambdas/pitchHandler/index.js
@@ -1,0 +1,51 @@
+const AWS = require("aws-sdk");
+const ses = new AWS.SES({ region: "eu-central-1" });
+
+exports.handler = async (event) => {
+  const data = JSON.parse(event.body);
+
+  const emailBody = `
+Subject: Pitch: “${data.track_title}” by Rue de Vivre — Perfect for ${data.brand_or_game}
+
+Hi ${data.recipient_name_or_team},
+
+I’m Rue de Vivre, and I’d love to share my track “${data.track_title}” for your ${data.brand_or_game}. Here’s why it fits:
+
+${data.theme_bullets}
+
+Listen: ${data.preview_link}
+Full Track (WAV/MP3/Stems): ${data.download_link}
+
+ASCAP Publisher Details
+
+IPI Base #: ${data.ascap_ipi_base}
+ASCAP Work ID: ${data.ascap_work_id}
+
+If you’re interested, just reply with:
+
+- Desired license term (e.g. exclusive/non-exclusive)
+- Usage details (scene, duration, territories)
+- Any special delivery format (stems, stems+dry vocal, stems+wet vocal)
+
+Best,
+Rue de Vivre  
+ops@decodedmusic.com  
+www.decodedmusic.com`;
+
+  const params = {
+    Destination: { ToAddresses: ["sync-target@example.com"] },
+    Message: {
+      Subject: { Data: `Pitch: “${data.track_title}” by Rue de Vivre` },
+      Body: { Text: { Data: emailBody } },
+    },
+    Source: "ops@decodedmusic.com",
+  };
+
+  await ses.sendEmail(params).promise();
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: "Pitch sent." }),
+    headers: { "Access-Control-Allow-Origin": "*" },
+  };
+};


### PR DESCRIPTION
## Summary
- create `pitchHandler` lambda to send sync licensing emails via SES
- extend `decodedMusicBackend.yaml` with Lambda, API Gateway and IAM role
- document pitch API deployment steps in README

## Testing
- `npm install --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684f65d64d408328b0569648c39c6557