### PR TITLE
Add artist dashboard backend

### DIFF
--- a/.github/workflows/dashboard-backend.yml
+++ b/.github/workflows/dashboard-backend.yml
@@ -1,0 +1,41 @@
+name: Deploy Decoded Music Artist Dashboard Backend
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: eu-central-1
+      DYNAMO_TABLE_EARNINGS: DecodedEarnings
+      DYNAMO_TABLE_STREAMS: DecodedStreams
+      DYNAMO_TABLE_CATALOG: DecodedCatalog
+      STRIPE_KEY: ${{ secrets.STRIPE_KEY }}
+      SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+      SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+      - name: Package Lambdas
+        run: |
+          cd backend/lambdas/dashboardEarnings && zip -r earnings.zip . && aws s3 cp earnings.zip s3://decodedmusic-lambda-code/ && cd -
+          cd backend/lambdas/dashboardStreams && zip -r streams.zip . && aws s3 cp streams.zip s3://decodedmusic-lambda-code/ && cd -
+          cd backend/lambdas/dashboardCatalog && zip -r catalog.zip . && aws s3 cp catalog.zip s3://decodedmusic-lambda-code/ && cd -
+          cd backend/lambdas/dashboardAnalytics && zip -r analytics.zip . && aws s3 cp analytics.zip s3://decodedmusic-lambda-code/ && cd -
+          cd backend/lambdas/dashboardStatements && zip -r statements.zip . && aws s3 cp statements.zip s3://decodedmusic-lambda-code/ && cd -
+          cd backend/lambdas/dashboardAccounting && zip -r accounting.zip . && aws s3 cp accounting.zip s3://decodedmusic-lambda-code/ && cd -
+          cd backend/lambdas/dashboardTeam && zip -r team.zip . && aws s3 cp team.zip s3://decodedmusic-lambda-code/ && cd -
+          cd backend/lambdas/dashboardCampaigns && zip -r campaigns.zip . && aws s3 cp campaigns.zip s3://decodedmusic-lambda-code/ && cd -
+      - name: Deploy CloudFormation
+        run: |
+          aws cloudformation deploy \
+            --template-file backend/cloudformation/decodedMusicBackend.yaml \
+            --stack-name DecodedMusicBackend \
+            --region $AWS_REGION \
+            --capabilities CAPABILITY_NAMED_IAM
+      - name: Test endpoint
+        run: curl -I https://n64vgs0he0.execute-api.eu-central-1.amazonaws.com/prod/dashboard/earnings

--- a/README.md
+++ b/README.md
@@ -142,6 +142,32 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
+## Artist Dashboard API
+Several Lambda functions under `backend/lambdas/` implement the `/api/dashboard/*` endpoints.
+Package and upload the code to S3 before deploying:
+
+```bash
+cd backend/lambdas/dashboardEarnings && zip -r earnings.zip . && aws s3 cp earnings.zip s3://decodedmusic-lambda-code/ && cd -
+```
+
+Repeat for the other dashboard lambda directories (`dashboardStreams`, `dashboardCatalog`, etc.).
+
+Deploy the updated CloudFormation stack:
+
+```bash
+aws cloudformation deploy \
+  --template-file backend/cloudformation/decodedMusicBackend.yaml \
+  --stack-name DecodedMusicBackend \
+  --region eu-central-1 \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+Verify the earnings endpoint:
+
+```bash
+curl https://n64vgs0he0.execute-api.eu-central-1.amazonaws.com/prod/dashboard/earnings
+```
+
 ## Running in Codex
 
 If you encounter a message like "Codex couldn't run certain commands due to environment limitations," make sure the container installs dependencies before running tests or other commands. A simple `setup.sh` script can be used. The script uses `npm ci` when a `package-lock.json` file is present, falling back to `npm install` otherwise:

--- a/backend/cloudformation/decodedMusicBackend.yaml
+++ b/backend/cloudformation/decodedMusicBackend.yaml
@@ -147,6 +147,350 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PitchApi}/*/POST/pitch
+
+  DashboardLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: dashboard-dynamo-access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:Scan
+                  - dynamodb:Query
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+
+  DashboardEarningsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardEarnings
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: earnings.zip
+
+  DashboardStreamsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardStreams
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: streams.zip
+
+  DashboardCatalogLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardCatalog
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: catalog.zip
+
+  DashboardAnalyticsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardAnalytics
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: analytics.zip
+
+  DashboardStatementsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardStatements
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: statements.zip
+
+  DashboardAccountingLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardAccounting
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: accounting.zip
+
+  DashboardTeamLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardTeam
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: team.zip
+
+  DashboardCampaignsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dashboardCampaigns
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: campaigns.zip
+
+  DashboardApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: DashboardAPI
+
+  DashboardResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt DashboardApi.RootResourceId
+      PathPart: dashboard
+      RestApiId: !Ref DashboardApi
+
+  EarningsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: earnings
+      RestApiId: !Ref DashboardApi
+
+  StreamsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: streams
+      RestApiId: !Ref DashboardApi
+
+  CatalogResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: catalog
+      RestApiId: !Ref DashboardApi
+
+  AnalyticsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: analytics
+      RestApiId: !Ref DashboardApi
+
+  StatementsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: statements
+      RestApiId: !Ref DashboardApi
+
+  AccountingResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: accounting
+      RestApiId: !Ref DashboardApi
+
+  TeamResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: team
+      RestApiId: !Ref DashboardApi
+
+  CampaignsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: campaigns
+      RestApiId: !Ref DashboardApi
+
+  EarningsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref EarningsResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardEarningsLambda.Arn}/invocations
+
+  StreamsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref StreamsResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardStreamsLambda.Arn}/invocations
+
+  CatalogMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref CatalogResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardCatalogLambda.Arn}/invocations
+
+  AnalyticsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref AnalyticsResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardAnalyticsLambda.Arn}/invocations
+
+  StatementsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref StatementsResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardStatementsLambda.Arn}/invocations
+
+  AccountingMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref AccountingResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardAccountingLambda.Arn}/invocations
+
+  TeamMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref TeamResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardTeamLambda.Arn}/invocations
+
+  CampaignsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref CampaignsResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardCampaignsLambda.Arn}/invocations
+
+  DashboardEarningsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardEarningsLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/earnings
+
+  DashboardStreamsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardStreamsLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/streams
+
+  DashboardCatalogPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardCatalogLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/catalog
+
+  DashboardAnalyticsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardAnalyticsLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/analytics
+
+  DashboardStatementsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardStatementsLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/statements
+
+  DashboardAccountingPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardAccountingLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/accounting
+
+  DashboardTeamPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardTeamLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/team
+
+  DashboardCampaignsPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardCampaignsLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/campaigns
 Outputs:
   ApiUrl:
     Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/prod/backend'
@@ -154,3 +498,6 @@ Outputs:
   PitchApiUrl:
     Value: !Sub 'https://${PitchApi}.execute-api.${AWS::Region}.amazonaws.com/prod/pitch'
     Description: Endpoint for sync licensing pitches
+  DashboardApiUrl:
+    Value: !Sub 'https://${DashboardApi}.execute-api.${AWS::Region}.amazonaws.com/prod/dashboard'
+    Description: Base URL for Artist Dashboard endpoints

--- a/backend/lambdas/dashboardAccounting/index.js
+++ b/backend/lambdas/dashboardAccounting/index.js
@@ -1,0 +1,7 @@
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify({ message: 'accounting placeholder' })
+  };
+};

--- a/backend/lambdas/dashboardAnalytics/index.js
+++ b/backend/lambdas/dashboardAnalytics/index.js
@@ -1,0 +1,7 @@
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify({ message: 'analytics placeholder' })
+  };
+};

--- a/backend/lambdas/dashboardCampaigns/index.js
+++ b/backend/lambdas/dashboardCampaigns/index.js
@@ -1,0 +1,7 @@
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify({ message: 'campaigns placeholder' })
+  };
+};

--- a/backend/lambdas/dashboardCatalog/index.js
+++ b/backend/lambdas/dashboardCatalog/index.js
@@ -1,0 +1,37 @@
+const { DynamoDBClient, QueryCommand, ScanCommand } = require('@aws-sdk/client-dynamodb');
+const REGION = process.env.AWS_REGION || 'eu-central-1';
+const TABLE = process.env.DYNAMO_TABLE_CATALOG || 'DecodedCatalog';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const qs = event.queryStringParameters || {};
+    let data;
+    if (qs.artist_id) {
+      data = await ddb.send(new QueryCommand({
+        TableName: TABLE,
+        KeyConditionExpression: 'artist_id = :a',
+        ExpressionAttributeValues: { ':a': { S: qs.artist_id } }
+      }));
+    } else {
+      data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
+    }
+    const items = (data.Items || []).map(clean);
+    return response(200, items);
+  } catch (err) {
+    console.error('catalog error', err);
+    return response(500, { message: 'Internal Server Error' });
+  }
+};
+
+function response(statusCode, body) {
+  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+}
+
+function clean(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    obj[k] = v.S ?? (v.N ? Number(v.N) : v.BOOL);
+  }
+  return obj;
+}

--- a/backend/lambdas/dashboardEarnings/index.js
+++ b/backend/lambdas/dashboardEarnings/index.js
@@ -1,0 +1,37 @@
+const { DynamoDBClient, QueryCommand, ScanCommand } = require('@aws-sdk/client-dynamodb');
+const REGION = process.env.AWS_REGION || 'eu-central-1';
+const TABLE = process.env.DYNAMO_TABLE_EARNINGS || 'DecodedEarnings';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const qs = event.queryStringParameters || {};
+    let data;
+    if (qs.artist_id) {
+      data = await ddb.send(new QueryCommand({
+        TableName: TABLE,
+        KeyConditionExpression: 'artist_id = :a',
+        ExpressionAttributeValues: { ':a': { S: qs.artist_id } }
+      }));
+    } else {
+      data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
+    }
+    const items = (data.Items || []).map(clean);
+    return response(200, items);
+  } catch (err) {
+    console.error('earnings error', err);
+    return response(500, { message: 'Internal Server Error' });
+  }
+};
+
+function response(statusCode, body) {
+  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+}
+
+function clean(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    obj[k] = v.S ?? (v.N ? Number(v.N) : v.BOOL);
+  }
+  return obj;
+}

--- a/backend/lambdas/dashboardStatements/index.js
+++ b/backend/lambdas/dashboardStatements/index.js
@@ -1,0 +1,7 @@
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify({ message: 'statements placeholder' })
+  };
+};

--- a/backend/lambdas/dashboardStreams/index.js
+++ b/backend/lambdas/dashboardStreams/index.js
@@ -1,0 +1,37 @@
+const { DynamoDBClient, QueryCommand, ScanCommand } = require('@aws-sdk/client-dynamodb');
+const REGION = process.env.AWS_REGION || 'eu-central-1';
+const TABLE = process.env.DYNAMO_TABLE_STREAMS || 'DecodedStreams';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const qs = event.queryStringParameters || {};
+    let data;
+    if (qs.artist_id) {
+      data = await ddb.send(new QueryCommand({
+        TableName: TABLE,
+        KeyConditionExpression: 'artist_id = :a',
+        ExpressionAttributeValues: { ':a': { S: qs.artist_id } }
+      }));
+    } else {
+      data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
+    }
+    const items = (data.Items || []).map(clean);
+    return response(200, items);
+  } catch (err) {
+    console.error('streams error', err);
+    return response(500, { message: 'Internal Server Error' });
+  }
+};
+
+function response(statusCode, body) {
+  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+}
+
+function clean(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    obj[k] = v.S ?? (v.N ? Number(v.N) : v.BOOL);
+  }
+  return obj;
+}

--- a/backend/lambdas/dashboardTeam/index.js
+++ b/backend/lambdas/dashboardTeam/index.js
@@ -1,0 +1,7 @@
+exports.handler = async () => {
+  return {
+    statusCode: 200,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify({ message: 'team placeholder' })
+  };
+};


### PR DESCRIPTION
## Summary
- add stubs for artist dashboard lambda functions
- extend CloudFormation template with `/dashboard` API resources
- document deployment in README
- add GitHub Actions workflow for packaging and deploying dashboard lambdas

## Testing
- `bash setup.sh`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_684f681470b88328b29f90440594d96c