### PR TITLE
Fix Signup region and remove Snap placeholder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,9 +51,7 @@
     u.parentNode.insertBefore(r,u);})(window,document,
     'https://sc-static.net/scevent.min.js');
 
-    snaptr('init', '0e29f2de-37c1-4e4f-8274-c4d2f40d4bd7', {
-    'user_email': '__INSERT_USER_EMAIL__' // Note: Replace with dynamic user email if available and applicable
-    });
+    snaptr('init', '0e29f2de-37c1-4e4f-8274-c4d2f40d4bd7');
 
     snaptr('track', 'PAGE_VIEW');
 

--- a/src/components/signup/SignupForm.jsx
+++ b/src/components/signup/SignupForm.jsx
@@ -19,7 +19,7 @@ export default function SignupForm({ type }) {
     e.preventDefault();
     setStatus("Submitting...");
     // Submit form data to the UseCaseManagementAPI Gateway endpoint
-    const response = await fetch("https://n64vgs0he0.execute-api.us-east-1.amazonaws.com/prod/signup", {
+    const response = await fetch("https://n64vgs0he0.execute-api.eu-central-1.amazonaws.com/prod/signup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(form),


### PR DESCRIPTION
## Summary
- clean up Snap Pixel snippet to remove placeholder email
- point the signup form's API call at the eu-central-1 endpoint

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6850cd5d97bc8328b570241564b8ed66