### PR TITLE
Implement catalog filters and pitch form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ STRIPE_PUBLISHABLE_KEY=your_stripe_publishable
 AWS_REGION=eu-central-1
 BEDROCK_MODEL_ID=anthropic.claude-3-sonnet-20240229-v1:0
 S3_BUCKET=your_bucket_name
+REACT_APP_PITCH_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/pitch
+REACT_APP_CATALOG_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/catalog

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ REACT_APP_SPOTIFY_REDIRECT_URI=http://localhost:3000/dashboard
 
 These values are read by the front-end to initiate the login process.
 
+## Catalog & Pitch API Setup
+
+The catalog browsing pages and pitch submission form expect API endpoints to be
+configured in your `.env` file:
+
+```bash
+REACT_APP_PITCH_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/pitch
+REACT_APP_CATALOG_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/catalog
+```
+
+These URLs are outputs of the `DecodedMusicBackend` CloudFormation stack.
+
 **Future Development:**
 
 *   Implement backend APIs for user authentication, catalog management, dynamic pricing calculation, licensing, and analytics.

--- a/src/components/catalog/FilterSidebar.jsx
+++ b/src/components/catalog/FilterSidebar.jsx
@@ -1,9 +1,118 @@
-import React from "react";
-export default function FilterSidebar() {
+import React, { useState } from "react";
+
+export default function FilterSidebar({ onChange }) {
+  const [filters, setFilters] = useState({
+    genre: "",
+    mood: "",
+    bpmMin: "",
+    bpmMax: "",
+    durationMin: "",
+    durationMax: "",
+    license: "",
+  });
+
+  function update(name, value) {
+    const next = { ...filters, [name]: value };
+    setFilters(next);
+    if (onChange) onChange(next);
+  }
+
+  function handleChange(e) {
+    update(e.target.name, e.target.value);
+  }
+
+  function clearFilters() {
+    const cleared = {
+      genre: "",
+      mood: "",
+      bpmMin: "",
+      bpmMax: "",
+      durationMin: "",
+      durationMax: "",
+      license: "",
+    };
+    setFilters(cleared);
+    if (onChange) onChange(cleared);
+  }
+
   return (
-    <aside className="w-64 p-4 border-r">
-      {/* TODO: Add genre, mood, BPM, duration, license filters */}
-      <div>Filter Sidebar</div>
+    <aside className="w-64 p-4 border-r space-y-4">
+      <div>
+        <label className="block font-semibold mb-1">Genre</label>
+        <input
+          name="genre"
+          value={filters.genre}
+          onChange={handleChange}
+          className="p-2 border rounded w-full"
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Mood</label>
+        <input
+          name="mood"
+          value={filters.mood}
+          onChange={handleChange}
+          className="p-2 border rounded w-full"
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">BPM</label>
+        <div className="flex space-x-2">
+          <input
+            name="bpmMin"
+            value={filters.bpmMin}
+            onChange={handleChange}
+            placeholder="Min"
+            className="p-2 border rounded w-full"
+          />
+          <input
+            name="bpmMax"
+            value={filters.bpmMax}
+            onChange={handleChange}
+            placeholder="Max"
+            className="p-2 border rounded w-full"
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Duration (sec)</label>
+        <div className="flex space-x-2">
+          <input
+            name="durationMin"
+            value={filters.durationMin}
+            onChange={handleChange}
+            placeholder="Min"
+            className="p-2 border rounded w-full"
+          />
+          <input
+            name="durationMax"
+            value={filters.durationMax}
+            onChange={handleChange}
+            placeholder="Max"
+            className="p-2 border rounded w-full"
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">License</label>
+        <select
+          name="license"
+          value={filters.license}
+          onChange={handleChange}
+          className="p-2 border rounded w-full"
+        >
+          <option value="">Any</option>
+          <option value="exclusive">Exclusive</option>
+          <option value="non-exclusive">Non-Exclusive</option>
+        </select>
+      </div>
+      <button
+        type="button"
+        onClick={clearFilters}
+        className="px-3 py-2 bg-gray-200 rounded"
+      >
+        Clear
+      </button>
     </aside>
   );
 }

--- a/src/components/catalog/PitchSubmissionForm.jsx
+++ b/src/components/catalog/PitchSubmissionForm.jsx
@@ -1,25 +1,72 @@
 import React, { useState } from "react";
 
+const API_URL = process.env.REACT_APP_PITCH_API_URL || "/api/pitch";
+
 export default function PitchSubmissionForm() {
-  const [form, setForm] = useState({ name: "", email: "", organization: "", message: "" });
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    organization: "",
+    message: "",
+  });
+  const [status, setStatus] = useState("");
 
   function handleChange(e) {
     setForm({ ...form, [e.target.name]: e.target.value });
   }
 
-  function handleSubmit(e) {
+  async function handleSubmit(e) {
     e.preventDefault();
-    // TODO: POST to Lambda endpoint
-    alert("Pitch submitted! (Not yet wired to backend)");
+    setStatus("Submitting...");
+    try {
+      const res = await fetch(API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error("Request failed");
+      setStatus("Pitch submitted! We will be in touch.");
+      setForm({ name: "", email: "", organization: "", message: "" });
+    } catch (err) {
+      console.error("Pitch submit error", err);
+      setStatus("There was an error sending your pitch.");
+    }
   }
 
   return (
     <form onSubmit={handleSubmit} className="p-4 border rounded">
-      <input name="name" placeholder="Name" value={form.name} onChange={handleChange} className="block mb-2 p-2 border rounded w-full" />
-      <input name="email" placeholder="Email" value={form.email} onChange={handleChange} className="block mb-2 p-2 border rounded w-full" />
-      <input name="organization" placeholder="Organization" value={form.organization} onChange={handleChange} className="block mb-2 p-2 border rounded w-full" />
-      <textarea name="message" placeholder="Message" value={form.message} onChange={handleChange} className="block mb-2 p-2 border rounded w-full" />
-      <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">Submit</button>
+      <input
+        name="name"
+        placeholder="Name"
+        value={form.name}
+        onChange={handleChange}
+        className="block mb-2 p-2 border rounded w-full"
+      />
+      <input
+        name="email"
+        placeholder="Email"
+        value={form.email}
+        onChange={handleChange}
+        className="block mb-2 p-2 border rounded w-full"
+      />
+      <input
+        name="organization"
+        placeholder="Organization"
+        value={form.organization}
+        onChange={handleChange}
+        className="block mb-2 p-2 border rounded w-full"
+      />
+      <textarea
+        name="message"
+        placeholder="Message"
+        value={form.message}
+        onChange={handleChange}
+        className="block mb-2 p-2 border rounded w-full"
+      />
+      <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">
+        Submit
+      </button>
+      {status && <div className="mt-2">{status}</div>}
     </form>
   );
 }

--- a/src/pages/catalog/BrowsePage.jsx
+++ b/src/pages/catalog/BrowsePage.jsx
@@ -1,15 +1,38 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import SearchBar from "../../components/catalog/SearchBar";
 import FilterSidebar from "../../components/catalog/FilterSidebar";
 import TrackGrid from "../../components/catalog/TrackGrid";
 
+const CATALOG_URL = process.env.REACT_APP_CATALOG_API_URL || "/api/catalog";
+
 export default function BrowsePage() {
+  const [tracks, setTracks] = useState([]);
+  const [filters, setFilters] = useState({});
+
+  useEffect(() => {
+    fetch(CATALOG_URL)
+      .then((res) => res.json())
+      .then(setTracks)
+      .catch((err) => console.error("Catalog fetch error", err));
+  }, []);
+
+  const filtered = tracks.filter((t) => {
+    if (filters.genre && !(t.genre || "").includes(filters.genre)) return false;
+    if (filters.mood && !(t.mood || "").includes(filters.mood)) return false;
+    if (filters.bpmMin && t.bpm < Number(filters.bpmMin)) return false;
+    if (filters.bpmMax && t.bpm > Number(filters.bpmMax)) return false;
+    if (filters.durationMin && t.duration < Number(filters.durationMin)) return false;
+    if (filters.durationMax && t.duration > Number(filters.durationMax)) return false;
+    if (filters.license && t.license_type !== filters.license) return false;
+    return true;
+  });
+
   return (
     <div className="flex">
-      <FilterSidebar />
+      <FilterSidebar onChange={setFilters} />
       <div className="flex-1">
         <SearchBar />
-        <TrackGrid />
+        <TrackGrid tracks={filtered} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add env vars for pitch submission and catalog endpoints
- document catalog and pitch API setup
- implement FilterSidebar with filtering UI and callbacks
- wire PitchSubmissionForm to backend
- fetch catalog tracks and filter client-side

## Testing
- `bash setup.sh`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6850d4bcb33c8328bc1920236fcf4a34