### PR TITLE
Add Facebook posting lambda

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ REACT_APP_CATALOG_API_URL=https://your-api-id.execute-api.region.amazonaws.com/p
 REACT_APP_SIGNUP_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/signup
 POST_IMAGE_URL=https://yourdomain.com/default-post.jpg
 PITCH_TARGET_EMAIL=sync@decodedmusic.com
+FACEBOOK_TOKEN=your_facebook_access_token
+FACEBOOK_PAGE_IDS=1234567890,9876543210

--- a/README.md
+++ b/README.md
@@ -297,3 +297,10 @@ insights and sends them back to Bedrock for a short performance summary saved to
 Configure `INSTAGRAM_TOKEN` and `INSTAGRAM_USER_ID` in your `.env` along with
 `AWS_REGION` and optional `BEDROCK_MODEL_ID`.
 
+## Facebook Poster Lambda
+
+`backend/lambda/facebookPoster` posts to one or more Facebook Pages using the
+Meta Graph API. Set `FACEBOOK_TOKEN` and a comma separated list of page IDs in
+`FACEBOOK_PAGE_IDS`. The function optionally uses Bedrock to generate the post
+content.
+

--- a/backend/lambda/facebookPoster/index.js
+++ b/backend/lambda/facebookPoster/index.js
@@ -1,0 +1,38 @@
+const fetch = require('node-fetch');
+const { BedrockRuntimeClient, InvokeModelCommand } = require('@aws-sdk/client-bedrock-runtime');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const MODEL_ID = process.env.BEDROCK_MODEL_ID || 'anthropic.claude-3-sonnet-20240229-v1:0';
+const PAGE_IDS = (process.env.FACEBOOK_PAGE_IDS || '').split(',').map(s => s.trim()).filter(Boolean);
+const TOKEN = process.env.FACEBOOK_TOKEN;
+
+async function generateMessage(topic) {
+  const client = new BedrockRuntimeClient({ region: REGION });
+  const prompt = `Write a short Facebook post about ${topic}. Include a playful call to action.`;
+  const command = new InvokeModelCommand({
+    modelId: MODEL_ID,
+    contentType: 'application/json',
+    accept: 'application/json',
+    body: JSON.stringify({ prompt, max_tokens: 120 })
+  });
+  const res = await client.send(command);
+  const completion = JSON.parse(new TextDecoder().decode(res.body)).completion;
+  return completion.trim();
+}
+
+async function postToPage(pageId, message) {
+  const url = `https://graph.facebook.com/v19.0/${pageId}/feed`;
+  await fetch(`${url}?access_token=${TOKEN}&message=${encodeURIComponent(message)}`, { method: 'POST' });
+}
+
+exports.handler = async (event = {}) => {
+  if (!TOKEN) throw new Error('FACEBOOK_TOKEN not set');
+  if (PAGE_IDS.length === 0) throw new Error('FACEBOOK_PAGE_IDS not configured');
+
+  const topic = event.topic || 'latest news';
+  const message = await generateMessage(topic);
+  for (const pageId of PAGE_IDS) {
+    await postToPage(pageId, message);
+  }
+  return { statusCode: 200, body: JSON.stringify({ posted: PAGE_IDS.length, message }) };
+};


### PR DESCRIPTION
## Summary
- add a lambda to post to Facebook pages using the Graph API
- document the function in README
- provide example env variables for Facebook credentials

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851149e3e5c8328a00a0d1b4f728a8a