### PR TITLE
Add deployment helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ After committing changes to GitHub you can deploy the build output to the Genera
    aws s3 sync build/ s3://YOUR_BUCKET_NAME --region eu-central-1 --delete
    ```
 
+### Automated deploy script
+
+The repository includes `automate-deploy-sync.sh` to perform the above steps in
+one command. Provide your target bucket via `DEPLOY_BUCKET`:
+
+```bash
+DEPLOY_BUCKET=YOUR_BUCKET_NAME ./automate-deploy-sync.sh
+```
+
 The CloudFront distribution <https://d1n11wdfy5g0ms.cloudfront.net/> (ID `E3POL8Z7WOOYIC`, ARN `arn:aws:cloudfront::396913703024:distribution/E3POL8Z7WOOYIC`) will serve the updated site once the files are uploaded.
 
 ## CloudFormation Deployment

--- a/automate-deploy-sync.sh
+++ b/automate-deploy-sync.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# automate-deploy-sync.sh
+# Pull latest code, build, and deploy to S3
+
+set -euo pipefail
+
+BUCKET="${DEPLOY_BUCKET:-}"
+REGION="${AWS_REGION:-eu-central-1}"
+
+if [ -z "$BUCKET" ]; then
+  echo "Usage: DEPLOY_BUCKET=your-bucket ./automate-deploy-sync.sh" >&2
+  exit 1
+fi
+
+echo "[1/5] Updating repository..."
+# Ensure repository is clean
+if ! git diff-index --quiet HEAD --; then
+  echo "Uncommitted changes detected. Stash or commit them before deploying." >&2
+  exit 1
+fi
+
+git pull --rebase
+
+echo "[2/5] Installing dependencies..."
+if [ -f package-lock.json ]; then
+  npm ci
+else
+  npm install
+fi
+
+echo "[3/5] Building project..."
+rm -rf build
+npm run build
+
+echo "[4/5] Syncing build to s3://$BUCKET (region: $REGION)..."
+aws s3 sync build/ "s3://$BUCKET" --region "$REGION" --delete
+
+echo "[5/5] Deployment complete."


### PR DESCRIPTION
## Summary
- add `automate-deploy-sync.sh` to pull, build, and sync to S3
- document the helper in the deployment section of the README

## Testing
- `bash setup.sh`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6852356cc31c83288a1ce949741fadbc