### PR TITLE
Update docs for decoded-genai-stack

### DIFF
--- a/.github/workflows/dashboard-backend.yml
+++ b/.github/workflows/dashboard-backend.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           aws cloudformation deploy \
             --template-file cloudformation/decodedMusicBackend.yaml \
-            --stack-name DecodedMusicBackend \
+            --stack-name decoded-genai-stack \
             --region $AWS_REGION \
             --capabilities CAPABILITY_NAMED_IAM
       - name: Test endpoint

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,6 +12,6 @@ jobs:
         run: |
           aws cloudformation deploy \
             --template-file cloudformation/decodedMusicBackend.yaml \
-            --stack-name DecodedMusicBackend \
+            --stack-name decoded-genai-stack \
             --region eu-central-1 \
             --capabilities CAPABILITY_NAMED_IAM

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ POST_IMAGE_URL=https://yourdomain.com/default-post.jpg
 PITCH_TARGET_EMAIL=sync@decodedmusic.com
 ```
 
-These URLs are outputs of the `DecodedMusicBackend` CloudFormation stack.
+These URLs are outputs of the `decoded-genai-stack` CloudFormation stack.
 
 **Future Development:**
 
@@ -151,7 +151,7 @@ Deploy the resources defined in `cloudformation/decodedMusicBackend.yaml` to exp
 ```bash
 aws cloudformation deploy \
   --template-file cloudformation/decodedMusicBackend.yaml \
-  --stack-name DecodedMusicBackend \
+  --stack-name decoded-genai-stack \
   --region eu-central-1 \
   --capabilities CAPABILITY_NAMED_IAM
 ```
@@ -171,7 +171,7 @@ Deploy the updated CloudFormation stack:
 ```bash
 aws cloudformation deploy \
   --template-file cloudformation/decodedMusicBackend.yaml \
-  --stack-name DecodedMusicBackend \
+  --stack-name decoded-genai-stack \
   --region eu-central-1 \
   --capabilities CAPABILITY_NAMED_IAM
 ```
@@ -255,20 +255,29 @@ The `EnvName` parameter defaults to `prod`. The example above explicitly
 passes `EnvName=prod`, but you can set a different value (e.g. `staging`) to
 create additional environments.
 
-### DecodedMusicBackend Stack
+### decoded-genai-stack (Active)
 
-Codex automation uses a backend CloudFormation stack named `DecodedMusicBackend`.
+Codex automation uses a backend CloudFormation stack named `decoded-genai-stack`.
 It provisions a Lambda function, API Gateway and DynamoDB table. Deploy it with:
 
 ```bash
 aws cloudformation deploy \
   --template-file cloudformation/decodedMusicBackend.yaml \
-  --stack-name DecodedMusicBackend \
+  --stack-name decoded-genai-stack \
   --region eu-central-1 \
   --capabilities CAPABILITY_NAMED_IAM
 ```
 
 After deployment the CloudFormation console should show a `CREATE_COMPLETE` status.
+
+If a previous stack named `DecodedMusicBackend` exists from a failed deployment,
+clean it up with:
+
+```bash
+aws cloudformation delete-stack \
+  --stack-name DecodedMusicBackend \
+  --region eu-central-1
+```
 
 ### Catalog API
 

--- a/docs/decodedmusic-backend-stack.md
+++ b/docs/decodedmusic-backend-stack.md
@@ -1,8 +1,8 @@
-# DecodedMusicBackend CloudFormation Stack
+# decoded-genai-stack CloudFormation Stack
 
 This stack is used by Codex and GitHub automation to provision the core backend services.
 
-- **Stack Name:** `DecodedMusicBackend`
+- **Stack Name:** `decoded-genai-stack`
 - **Resources:** AWS Lambda, API Gateway and a DynamoDB table
 - After deployment the CloudFormation console should show a status of `CREATE_COMPLETE`.
 
@@ -11,8 +11,16 @@ Deploy with:
 ```bash
 aws cloudformation deploy \
   --template-file cloudformation/decodedMusicBackend.yaml \
-  --stack-name DecodedMusicBackend \
+  --stack-name decoded-genai-stack \
   --region eu-central-1 \
   --capabilities CAPABILITY_NAMED_IAM
+
+To remove an old stack named `DecodedMusicBackend` run:
+
+```bash
+aws cloudformation delete-stack \
+  --stack-name DecodedMusicBackend \
+  --region eu-central-1
+```
 ```
 


### PR DESCRIPTION
## Summary
- update references to the active `decoded-genai-stack`
- document command to delete the old `DecodedMusicBackend` stack
- adjust workflow deployment stack names

## Testing
- `./setup.sh`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6852eef9a15083288b862c7e9109ee51