### PR TITLE
Add CloudFormation troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ These URLs are outputs of the `decoded-genai-stack` CloudFormation stack.
     for the catalog upload and metadata extraction pipeline.
 *   See [docs/subscription-system.md](docs/subscription-system.md)
     for the artist subscription workflow and company revenue reporting.
+*   See [docs/troubleshooting-cloudformation.md](docs/troubleshooting-cloudformation.md)
+    for tips on diagnosing CloudFormation stack failures.
 
 
 ## Signup Lambda Function

--- a/docs/troubleshooting-cloudformation.md
+++ b/docs/troubleshooting-cloudformation.md
@@ -1,0 +1,16 @@
+# Troubleshooting CloudFormation Stack Failures
+
+If a stack creation fails, inspect the events to locate the resource that triggered `CREATE_FAILED`.
+
+1. Open the **CloudFormation** console and select your stack.
+2. Choose the **Events** tab and scroll to the earliest entries.
+3. The row marked `CREATE_FAILED` lists the failed resource and an error message.
+
+You can also retrieve these details via the AWS CLI:
+
+```bash
+aws cloudformation describe-stack-events --stack-name <your-stack-name> \
+  --query 'StackEvents[?ResourceStatus==`CREATE_FAILED`]' --output table
+```
+
+Look for the `ResourceStatusReason` field to determine why the resource failed.


### PR DESCRIPTION
## Summary
- document how to find CREATE_FAILED events for a stack
- link to the new doc from README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68530ff7babc8328aec88e6234f45f34