### PR TITLE
Add dashboard API module

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,0 +1,45 @@
+const API_BASE = process.env.REACT_APP_API_BASE;
+
+export const DashboardAPI = {
+  getAccounting: (payload) =>
+    fetch(`${API_BASE}/accounting`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json()),
+
+  getAnalytics: (payload) =>
+    fetch(`${API_BASE}/analytics`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json()),
+
+  getCampaigns: (payload) =>
+    fetch(`${API_BASE}/campaigns`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json()),
+
+  getTeam: (payload) =>
+    fetch(`${API_BASE}/team`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json()),
+
+  getStreams: (payload) =>
+    fetch(`${API_BASE}/streams`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json()),
+
+  getStatements: (payload) =>
+    fetch(`${API_BASE}/statements`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json()),
+};

--- a/src/pages/Accounting.jsx
+++ b/src/pages/Accounting.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { DashboardAPI } from '../api/dashboard';
 
 const API_BASE = process.env.REACT_APP_API_BASE || '/api/dashboard';
 
@@ -8,15 +9,8 @@ function Accounting() {
   useEffect(() => {
     async function fetchAccounting() {
       try {
-        const res = await fetch(`${API_BASE}/accounting`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ artistId: 'RueDeVivre' })
-        });
-        if (res.ok) {
-          const data = await res.json();
-          setSummary(data);
-        }
+        const data = await DashboardAPI.getAccounting({ artistId: 'RueDeVivre' });
+        setSummary(data);
       } catch (err) {
         console.error('fetch accounting error', err);
       }

--- a/src/pages/ArtistDashboard.js
+++ b/src/pages/ArtistDashboard.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-
-const API_BASE = process.env.REACT_APP_API_BASE || '/api/dashboard';
+import { DashboardAPI } from '../api/dashboard';
 
 const CLIENT_ID = process.env.REACT_APP_SPOTIFY_CLIENT_ID;
 const REDIRECT_URI = process.env.REACT_APP_SPOTIFY_REDIRECT_URI || window.location.origin + '/dashboard';
@@ -29,14 +28,8 @@ function ArtistDashboard() {
 
     async function loadData() {
       try {
-        const res = await fetch(`${API_BASE}/accounting`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ artistId: 'RueDeVivre' })
-        });
-        if (res.ok) {
-          setAccounting(await res.json());
-        }
+        const data = await DashboardAPI.getAccounting({ artistId: 'RueDeVivre' });
+        setAccounting(data);
       } catch (err) {
         console.error('dashboard fetch error', err);
       }


### PR DESCRIPTION
## Summary
- centralize fetch calls into `DashboardAPI`
- update `ArtistDashboard` and `Accounting` pages to use new API helpers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6853b2d6f16c8328938e0406698d4ac4