### PR TITLE
Graceful stub responses for dashboard lambdas

### DIFF
--- a/backend/lambda/dashboardAnalytics/index.js
+++ b/backend/lambda/dashboardAnalytics/index.js
@@ -3,6 +3,7 @@ const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.DYNAMO_TABLE_ANALYTICS || 'WeeklyArtistStats';
 const ddb = new DynamoDBClient({ region: REGION });
+const DEFAULT_STATS = [{ week_start: '2025-01-01', spotify_streams: 0, youtube_views: 0 }];
 
 exports.handler = async (event) => {
   try {
@@ -20,7 +21,7 @@ exports.handler = async (event) => {
     }));
 
     const items = (data.Items || []).map(clean);
-    return response(200, items);
+    return response(200, items.length ? items : DEFAULT_STATS);
   } catch (err) {
     console.error('analytics error', err);
     return response(500, { message: 'Internal Server Error' });

--- a/backend/lambda/dashboardCampaigns/index.js
+++ b/backend/lambda/dashboardCampaigns/index.js
@@ -3,6 +3,7 @@ const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.SPEND_TABLE || 'MarketingSpend';
 const ddb = new DynamoDBClient({ region: REGION });
+const DEFAULT_CAMPAIGNS = [{ campaign_id: 'stub', spent_cents: 0 }];
 
 exports.handler = async (event) => {
   try {
@@ -24,7 +25,7 @@ exports.handler = async (event) => {
       grouped[id] = (grouped[id] || 0) + (item.spent_cents || 0);
     }
     const campaigns = Object.entries(grouped).map(([campaign_id, spent_cents]) => ({ campaign_id, spent_cents }));
-    return response(200, campaigns);
+    return response(200, campaigns.length ? campaigns : DEFAULT_CAMPAIGNS);
   } catch (err) {
     console.error('campaigns error', err);
     return response(500, { message: 'Internal Server Error' });

--- a/backend/lambda/dashboardCatalog/index.js
+++ b/backend/lambda/dashboardCatalog/index.js
@@ -2,6 +2,7 @@ const { DynamoDBClient, QueryCommand, ScanCommand } = require('@aws-sdk/client-d
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.DYNAMO_TABLE_CATALOG || 'DecodedCatalog';
 const ddb = new DynamoDBClient({ region: REGION });
+const DEFAULT_CATALOG = [{ id: 'stub', title: 'Sample Track', artist_id: 'stub' }];
 
 exports.handler = async (event) => {
   try {
@@ -17,7 +18,7 @@ exports.handler = async (event) => {
       data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
     }
     const items = (data.Items || []).map(clean);
-    return response(200, items);
+    return response(200, items.length ? items : DEFAULT_CATALOG);
   } catch (err) {
     console.error('catalog error', err);
     return response(500, { message: 'Internal Server Error' });

--- a/backend/lambda/dashboardEarnings/index.js
+++ b/backend/lambda/dashboardEarnings/index.js
@@ -2,6 +2,7 @@ const { DynamoDBClient, QueryCommand, ScanCommand } = require('@aws-sdk/client-d
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.DYNAMO_TABLE_EARNINGS || 'DecodedEarnings';
 const ddb = new DynamoDBClient({ region: REGION });
+const DEFAULT_EARNINGS = [{ artist_id: 'stub', month: '2025-01', revenue_cents: 0 }];
 
 exports.handler = async (event) => {
   try {
@@ -17,7 +18,7 @@ exports.handler = async (event) => {
       data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
     }
     const items = (data.Items || []).map(clean);
-    return response(200, items);
+    return response(200, items.length ? items : DEFAULT_EARNINGS);
   } catch (err) {
     console.error('earnings error', err);
     return response(500, { message: 'Internal Server Error' });

--- a/backend/lambda/dashboardStatements/index.js
+++ b/backend/lambda/dashboardStatements/index.js
@@ -3,6 +3,7 @@ const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.DYNAMO_TABLE_STATEMENTS || 'Statements';
 const ddb = new DynamoDBClient({ region: REGION });
+const DEFAULT_STATEMENTS = [{ statement_id: 'stub', amount_cents: 0, period: '2025-01' }];
 
 exports.handler = async (event) => {
   try {
@@ -20,7 +21,7 @@ exports.handler = async (event) => {
     }));
 
     const items = (data.Items || []).map(clean);
-    return response(200, items);
+    return response(200, items.length ? items : DEFAULT_STATEMENTS);
   } catch (err) {
     console.error('statements error', err);
     return response(500, { message: 'Internal Server Error' });

--- a/backend/lambda/dashboardStreams/index.js
+++ b/backend/lambda/dashboardStreams/index.js
@@ -2,6 +2,7 @@ const { DynamoDBClient, QueryCommand, ScanCommand } = require('@aws-sdk/client-d
 const REGION = process.env.AWS_REGION || 'eu-central-1';
 const TABLE = process.env.DYNAMO_TABLE_STREAMS || 'DecodedStreams';
 const ddb = new DynamoDBClient({ region: REGION });
+const DEFAULT_STREAMS = [{ artist_id: 'stub', play_count: 0 }];
 
 exports.handler = async (event) => {
   try {
@@ -17,7 +18,7 @@ exports.handler = async (event) => {
       data = await ddb.send(new ScanCommand({ TableName: TABLE, Limit: 50 }));
     }
     const items = (data.Items || []).map(clean);
-    return response(200, items);
+    return response(200, items.length ? items : DEFAULT_STREAMS);
   } catch (err) {
     console.error('streams error', err);
     return response(500, { message: 'Internal Server Error' });


### PR DESCRIPTION
## Summary
- add default response objects to all dashboard lambdas
- return stub data when queries return no results

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855da110a5c8328879152a5734fee43