### PR TITLE
Add Spotify stats module

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ These URLs are outputs of the `decoded-genai-stack` CloudFormation stack.
     for the artist subscription workflow and company revenue reporting.
 *   See [docs/troubleshooting-cloudformation.md](docs/troubleshooting-cloudformation.md)
     for tips on diagnosing CloudFormation stack failures.
+*   See [docs/spotify-module.md](docs/spotify-module.md)
+    for the weekly Spotify fetcher and dashboard panel.
 
 
 ## Signup Lambda Function

--- a/backend/lambda/dashboardSpotify/index.js
+++ b/backend/lambda/dashboardSpotify/index.js
@@ -1,0 +1,38 @@
+const { DynamoDBClient, QueryCommand } = require('@aws-sdk/client-dynamodb');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.SPOTIFY_TABLE || 'SpotifyArtistData';
+const ddb = new DynamoDBClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const qs = event.queryStringParameters || {};
+    if (!qs.artist_id) return response(400, { message: 'artist_id required' });
+    const data = await ddb.send(new QueryCommand({
+      TableName: TABLE,
+      KeyConditionExpression: 'artist_id = :a',
+      ExpressionAttributeValues: { ':a': { S: qs.artist_id } },
+      ScanIndexForward: false,
+      Limit: 1
+    }));
+    const item = data.Items?.[0] ? clean(data.Items[0]) : {};
+    return response(200, item);
+  } catch (err) {
+    console.error('spotify dashboard error', err);
+    return response(500, { message: 'Internal Server Error' });
+  }
+};
+
+function response(statusCode, body) {
+  return { statusCode, headers: { 'Access-Control-Allow-Origin': '*' }, body: JSON.stringify(body) };
+}
+
+function clean(item) {
+  const obj = {};
+  for (const [k, v] of Object.entries(item)) {
+    obj[k] = v.S ?? (v.N ? Number(v.N) : v.BOOL);
+  }
+  if (obj.top_tracks) obj.top_tracks = JSON.parse(obj.top_tracks);
+  if (obj.trending) obj.trending = JSON.parse(obj.trending);
+  return obj;
+}

--- a/backend/lambda/package-and-upload-all.sh
+++ b/backend/lambda/package-and-upload-all.sh
@@ -12,6 +12,8 @@ lambdas=(
   dashboardAccounting
   dashboardTeam
   dashboardCampaigns
+  dashboardSpotify
+  spotifyArtistFetcher
 )
 
 for fn in "${lambdas[@]}"; do

--- a/backend/lambda/spotifyArtistFetcher/index.js
+++ b/backend/lambda/spotifyArtistFetcher/index.js
@@ -1,0 +1,53 @@
+const fetch = require('node-fetch');
+const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
+
+const REGION = process.env.AWS_REGION || 'us-east-1';
+const TABLE = process.env.SPOTIFY_TABLE || 'SpotifyArtistData';
+const ARTIST_IDS = (process.env.ARTIST_IDS || '').split(',').map(s => s.trim()).filter(Boolean);
+const ddb = new DynamoDBClient({ region: REGION });
+
+async function getToken() {
+  const id = process.env.SPOTIFY_CLIENT_ID;
+  const secret = process.env.SPOTIFY_CLIENT_SECRET;
+  const auth = Buffer.from(`${id}:${secret}`).toString('base64');
+  const res = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: 'grant_type=client_credentials'
+  });
+  const json = await res.json();
+  return json.access_token;
+}
+
+async function getArtistData(token, artistId) {
+  const headers = { Authorization: `Bearer ${token}` };
+  const base = 'https://api.spotify.com/v1';
+  const profile = await fetch(`${base}/artists/${artistId}`, { headers }).then(r => r.json());
+  const top = await fetch(`${base}/artists/${artistId}/top-tracks?market=US`, { headers }).then(r => r.json());
+  const cats = await fetch(`${base}/browse/categories?limit=5`, { headers }).then(r => r.json());
+  return { profile, top: top.tracks || [], categories: cats.categories?.items || [] };
+}
+
+exports.handler = async () => {
+  if (!ARTIST_IDS.length) throw new Error('No ARTIST_IDS configured');
+  const token = await getToken();
+  const week = new Date().toISOString().slice(0,10);
+  const tasks = ARTIST_IDS.map(async id => {
+    const data = await getArtistData(token, id);
+    const item = {
+      artist_id: { S: id },
+      week_start: { S: week },
+      name: { S: data.profile.name || '' },
+      followers: { N: String(data.profile.followers?.total || 0) },
+      popularity: { N: String(data.profile.popularity || 0) },
+      top_tracks: { S: JSON.stringify(data.top.map(t => ({ id: t.id, name: t.name }))) },
+      trending: { S: JSON.stringify(data.categories.map(c => c.name)) }
+    };
+    await ddb.send(new PutItemCommand({ TableName: TABLE, Item: item }));
+  });
+  await Promise.all(tasks);
+  return { statusCode: 200, body: JSON.stringify({ saved: ARTIST_IDS.length }) };
+};

--- a/cloudformation/decodedMusicBackend.yaml
+++ b/cloudformation/decodedMusicBackend.yaml
@@ -273,6 +273,20 @@ Resources:
         S3Bucket: decodedmusic-lambda-code
         S3Key: dashboardCampaigns.zip
 
+  DashboardSpotifyLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${EnvName}-dashboardSpotify"
+      Handler: index.handler
+      Runtime: nodejs18.x
+      Role: !GetAtt DashboardLambdaRole.Arn
+      Environment:
+        Variables:
+          SPOTIFY_TABLE: !Sub '${EnvName}-SpotifyArtistData'
+      Code:
+        S3Bucket: decodedmusic-lambda-code
+        S3Key: dashboardSpotify.zip
+
   DashboardApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
@@ -339,6 +353,13 @@ Resources:
     Properties:
       ParentId: !Ref DashboardResource
       PathPart: campaigns
+      RestApiId: !Ref DashboardApi
+
+  SpotifyResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !Ref DashboardResource
+      PathPart: spotify
       RestApiId: !Ref DashboardApi
 
   EarningsMethod:
@@ -437,6 +458,18 @@ Resources:
         Type: AWS_PROXY
         Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardCampaignsLambda.Arn}/invocations
 
+  SpotifyMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId: !Ref SpotifyResource
+      RestApiId: !Ref DashboardApi
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DashboardSpotifyLambda.Arn}/invocations
+
   DashboardEarningsPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -500,6 +533,14 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/campaigns
+
+  DashboardSpotifyPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref DashboardSpotifyLambda
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DashboardApi}/*/*/dashboard/spotify
 Outputs:
   ApiUrl:
     Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/prod/backend'

--- a/cloudformation/marketing-hub.yml
+++ b/cloudformation/marketing-hub.yml
@@ -87,6 +87,22 @@ Resources:
         - AttributeName: week_start
           KeyType: RANGE
       BillingMode: PAY_PER_REQUEST
+
+  SpotifyArtistDataTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${EnvName}-SpotifyArtistData'
+      AttributeDefinitions:
+        - AttributeName: artist_id
+          AttributeType: S
+        - AttributeName: week_start
+          AttributeType: S
+      KeySchema:
+        - AttributeName: artist_id
+          KeyType: HASH
+        - AttributeName: week_start
+          KeyType: RANGE
+      BillingMode: PAY_PER_REQUEST
   MarketingLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -153,6 +169,20 @@ Resources:
       Environment:
         Variables:
           STATS_TABLE: !Ref WeeklyArtistStatsTable
+
+  SpotifyArtistFetcher:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub '${EnvName}-spotify-artist-fetcher'
+      Runtime: nodejs18.x
+      Handler: index.handler
+      Role: !GetAtt MarketingLambdaRole.Arn
+      Code:
+        S3Bucket: placeholder-bucket
+        S3Key: marketing/spotifyArtistFetcher.zip
+      Environment:
+        Variables:
+          SPOTIFY_TABLE: !Ref SpotifyArtistDataTable
   ApiGatewayMarketing:
     Type: AWS::ApiGateway::Resource
     Properties:
@@ -195,6 +225,22 @@ Resources:
       FunctionName: !Ref WeeklyStatsLogger
       Principal: events.amazonaws.com
       SourceArn: !GetAtt WeeklyStatsRule.Arn
+
+  SpotifyFetchRule:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression: 'cron(0 12 ? * WED *)'
+      Targets:
+        - Arn: !GetAtt SpotifyArtistFetcher.Arn
+          Id: SpotifyArtistFetcherTarget
+
+  SpotifyFetchPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref SpotifyArtistFetcher
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt SpotifyFetchRule.Arn
 Outputs:
   MarketingApiUrl:
     Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com/prod/marketing'

--- a/cloudformation/music-management.yml
+++ b/cloudformation/music-management.yml
@@ -93,6 +93,22 @@ Resources:
           KeyType: RANGE
       BillingMode: PAY_PER_REQUEST
 
+  SpotifyArtistDataTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${EnvName}-SpotifyArtistData'
+      AttributeDefinitions:
+        - AttributeName: artist_id
+          AttributeType: S
+        - AttributeName: week_start
+          AttributeType: S
+      KeySchema:
+        - AttributeName: artist_id
+          KeyType: HASH
+        - AttributeName: week_start
+          KeyType: RANGE
+      BillingMode: PAY_PER_REQUEST
+
   StatementsTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/deploy-all-lambdas.sh
+++ b/deploy-all-lambdas.sh
@@ -18,6 +18,8 @@ declare -A lambdas=(
   [DashboardStatementsLambda]="dashboardStatements.zip"
   [DashboardStreamsLambda]="dashboardStreams.zip"
   [DashboardTeamLambda]="dashboardTeam.zip"
+  [DashboardSpotifyLambda]="dashboardSpotify.zip"
+  [SpotifyArtistFetcherLambda]="spotifyArtistFetcher.zip"
   [PitchLambda]="pitchHandler.zip"
 )
 

--- a/docs/artist-dashboard-plan.md
+++ b/docs/artist-dashboard-plan.md
@@ -64,5 +64,6 @@ This document outlines a proposed backend structure for the Artist Dashboard and
 | `/api/dashboard/analytics` | Detailed analytics data |
 | `/api/dashboard/statements` | Downloadable royalty statements |
 | `/api/dashboard/team` | Manage team roles and permissions |
+| `/api/dashboard/spotify` | Weekly Spotify stats and trending genres |
 
 These endpoints are placeholders to demonstrate how the dashboard might interact with a backend service. They can be implemented using serverless functions or a traditional API depending on infrastructure choices.

--- a/docs/spotify-module.md
+++ b/docs/spotify-module.md
@@ -1,0 +1,29 @@
+# Spotify Data Module
+
+This module pulls artist data from the Spotify Web API on a weekly schedule and exposes it to the Artist Dashboard.
+
+## DynamoDB Table – `SpotifyArtistData`
+
+| Field | Example | Description |
+| --- | --- | --- |
+| `artist_id` | `293x3NAIGPR4RCJrFkzs0P` | Spotify artist ID |
+| `week_start` | `2025-06-18` | Monday of the data week |
+| `name` | `Rue de Vivre` | Artist name |
+| `followers` | `12345` | Total Spotify followers |
+| `popularity` | `55` | Spotify popularity score |
+| `top_tracks` | `[ {"id": "abc", "name": "Fireproof"} ]` | JSON list of top tracks |
+| `trending` | `["reggaeton","pop"]` | Names of trending categories |
+
+Partition key is `artist_id` with `week_start` as a sort key so historical snapshots can be retained.
+
+## Weekly Fetch Lambda
+
+`spotifyArtistFetcher` runs every **Wednesday** via EventBridge. It authenticates using `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET`, pulls profile, top tracks and a sample of trending categories for each `ARTIST_IDS` entry and writes the data to `SpotifyArtistData`.
+
+## Dashboard Endpoint
+
+`dashboardSpotify` is a simple read-only Lambda behind `/api/dashboard/spotify`. It returns the most recent record for a given `artist_id` so the frontend can display follower counts, top tracks and trend hints.
+
+## Frontend Panel
+
+The React dashboard imports `SpotifyModule` which calls `/api/dashboard/spotify?artist_id=...` and renders the results in a sidebar frame.

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -42,4 +42,11 @@ export const DashboardAPI = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     }).then((res) => res.json()),
+
+  getSpotifyData: (payload) =>
+    fetch(`${API_BASE}/spotify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((res) => res.json()),
 };

--- a/src/components/SpotifyModule.js
+++ b/src/components/SpotifyModule.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { DashboardAPI } from '../api/dashboard';
+
+function SpotifyModule() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    async function fetchSpotify() {
+      try {
+        const res = await DashboardAPI.getSpotifyData({ artistId: 'RueDeVivre' });
+        setData(res);
+      } catch (err) {
+        console.error('spotify fetch error', err);
+      }
+    }
+    fetchSpotify();
+  }, []);
+
+  if (!data) {
+    return <div style={{ border: '1px solid #ccc', padding: '1rem' }}>Loading Spotify data...</div>;
+  }
+
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem' }}>
+      <h2>Spotify Profile</h2>
+      <div>{data.name}</div>
+      <div>Followers: {data.followers}</div>
+      <div>Popularity: {data.popularity}</div>
+      {Array.isArray(data.top_tracks) && (
+        <div>
+          <h3>Top Tracks</h3>
+          <ul>
+            {data.top_tracks.map(t => (
+              <li key={t.id}>{t.name}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {Array.isArray(data.trending) && (
+        <div>
+          <h3>Trending</h3>
+          <ul>
+            {data.trending.map((c, i) => (
+              <li key={i}>{c}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SpotifyModule;

--- a/src/pages/ArtistDashboard.js
+++ b/src/pages/ArtistDashboard.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { DashboardAPI } from '../api/dashboard';
+import SpotifyModule from '../components/SpotifyModule';
 
 const CLIENT_ID = process.env.REACT_APP_SPOTIFY_CLIENT_ID;
 const REDIRECT_URI = process.env.REACT_APP_SPOTIFY_REDIRECT_URI || window.location.origin + '/dashboard';
@@ -52,16 +53,21 @@ function ArtistDashboard() {
   }
 
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Artist Dashboard</h1>
-      <p>You are logged in with Spotify.</p>
-      {accounting && (
-        <div style={{ marginTop: '1rem' }}>
-          <div>Total Revenue: ${(accounting.totalRevenue / 100).toFixed(2)}</div>
-          <div>Total Expenses: ${(accounting.totalExpenses / 100).toFixed(2)}</div>
-          <div>Net Revenue: ${(accounting.netRevenue / 100).toFixed(2)}</div>
-        </div>
-      )}
+    <div style={{ padding: '2rem', display: 'flex', gap: '1rem' }}>
+      <div style={{ flex: '0 0 280px' }}>
+        <SpotifyModule />
+      </div>
+      <div style={{ flex: 1 }}>
+        <h1>Artist Dashboard</h1>
+        <p>You are logged in with Spotify.</p>
+        {accounting && (
+          <div style={{ marginTop: '1rem' }}>
+            <div>Total Revenue: {(accounting.totalRevenue / 100).toFixed(2)}</div>
+            <div>Total Expenses: {(accounting.totalExpenses / 100).toFixed(2)}</div>
+            <div>Net Revenue: {(accounting.netRevenue / 100).toFixed(2)}</div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create Spotify data logger lambda and API reader
- display Spotify info sidebar in artist dashboard
- package new lambdas for deploy
- schedule weekly fetch in CloudFormation
- document Spotify module

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855f7c3c9cc832888e5acd52c8876a8