### PR TITLE
Remove third-party font stylesheets

### DIFF
--- a/public/buzz.html
+++ b/public/buzz.html
@@ -5,7 +5,35 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Buzz - Daily Music Management Research</title>
   <meta name="description" content="Your daily music industry sweep covering deals, disputes, sync events, and unauthorized music use.">
-  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.0.24/dist/tailwind.min.css" rel="stylesheet">
+  <!-- Inline styles to avoid third-party stylesheets -->
+  <style>
+    body { background:#fff; color:#1F2937; font-family: Arial, sans-serif; }
+    .container { max-width:28rem; margin:0 auto; padding:1rem; }
+    .max-w-md { max-width:28rem; }
+    .mx-auto { margin-left:auto; margin-right:auto; }
+    .p-4 { padding:1rem; }
+    .mb-4 { margin-bottom:1rem; }
+    .mt-4 { margin-top:1rem; }
+    .mt-6 { margin-top:1.5rem; }
+    .text-center { text-align:center; }
+    .text-xl { font-size:1.25rem; }
+    .text-sm { font-size:0.875rem; }
+    .text-xs { font-size:0.75rem; }
+    .text-gray-500 { color:#6B7280; }
+    .text-gray-400 { color:#9CA3AF; }
+    .font-bold { font-weight:bold; }
+    .whitespace-pre-wrap { white-space:pre-wrap; }
+    .space-x-2 > * + * { margin-left:0.5rem; }
+    .px-4 { padding-left:1rem; padding-right:1rem; }
+    .py-2 { padding-top:0.5rem; padding-bottom:0.5rem; }
+    .rounded-xl { border-radius:0.75rem; }
+    button { padding:0.5rem 1rem; border-radius:0.75rem; }
+    .bg-blue-600 { background-color:#2563eb; color:#fff; }
+    .text-blue-600 { color:#2563eb; }
+    .text-blue-500 { color:#3B82F6; }
+    .border { border:1px solid; }
+    .border-blue-600 { border-color:#2563eb; }
+  </style>
 </head>
 <body class="bg-white text-gray-800">
   <div class="max-w-md mx-auto p-4">

--- a/public/index.html
+++ b/public/index.html
@@ -24,30 +24,13 @@
     <title>Decoded Music | Price Revolution</title>
 
     <!-- ✅ Fonts and Styles -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-      crossorigin="anonymous"
-    />
-
-    <!-- Optional font face fallback for FA (avoids FOUC) -->
-    <style>
-      @font-face {
-        font-family: 'Font Awesome 6 Free';
-        font-style: normal;
-        font-weight: 900;
-        font-display: block;
-      }
-    </style>
+    <!-- Avoid third-party stylesheets for fonts -->
 
     <!-- ✅ Base Styles -->
     <style>
       body {
         margin: 0;
-        font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+        font-family: 'Helvetica', 'Arial', sans-serif;
         background-color: #111;
         color: #fff;
         -webkit-font-smoothing: antialiased;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary
- drop Google Fonts and Font Awesome links
- inline styles for `buzz.html` so no CDN Tailwind
- use system fonts in CSS

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685700b09e1c8328b72afa08df3a5b9c