### PR TITLE
Fix YAML brace spacing

### DIFF
--- a/cloudformation/signupApi.yml
+++ b/cloudformation/signupApi.yml
@@ -35,7 +35,7 @@ Resources:
         Type: AWS_PROXY
         Uri: !Sub
           - arn:aws:apigateway:${Region}:lambda:path/2015-03-31/functions/${LambdaArn}/invocations
-          - { Region: !Ref "AWS::Region", LambdaArn: !GetAtt SignupLambdaFunction.Arn }
+          - {Region: !Ref "AWS::Region", LambdaArn: !GetAtt SignupLambdaFunction.Arn}
 
   LambdaPermissionForSignup:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Summary
- fix lint warnings in signupApi by removing extra spacing in braces

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable}}' cloudformation/signupApi.yml`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_685707b7219083288ce5da0f45f03c10