### PR TITLE
Fix hero video and logo centering

### DIFF
--- a/src/sections/Section1Hero.js
+++ b/src/sections/Section1Hero.js
@@ -17,7 +17,7 @@ function Section1Hero() {
         <div className={styles.overlay}></div> {/* Dark overlay */}
       </div>
       <div className={styles.framedContent}> {/* New container for the "framed" look */}
-        <img src={decodedMusicLogo} alt="Decoded Music Logo" className="h-10 w-auto" />
+        <img src={decodedMusicLogo} alt="Decoded Music Logo" className={styles.logo} />
         <h1 className={styles.headline}>{content.hero.headline}</h1>
         <p className={styles.tagline}>{content.hero.tagline}</p> {/* Use tagline from JSON */}
         <p className={styles.hypeText}>

--- a/src/styles/Section1Hero.module.css
+++ b/src/styles/Section1Hero.module.css
@@ -17,13 +17,18 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  z-index: 1; /* Below content and overlay */
+  z-index: 0; /* Base layer */
 }
 
 .video {
-  width: 100%;
-  height: 100%;
-  object-fit: cover; /* Cover the container while maintaining aspect ratio */
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  min-width: 100%;
+  min-height: 100%;
+  transform: translate(-50%, -50%);
+  object-fit: cover;
+  z-index: 0;
 }
 
 .overlay {
@@ -33,12 +38,12 @@
   width: 100%;
   height: 100%;
   background: rgba(17, 17, 17, 0.6); /* #111 with alpha for semi-transparency */
-  z-index: 2; /* Between video and content */
+  z-index: 1; /* Above video */
 }
 
 .framedContent { /* This div gets the 'framed' look */
   position: relative;
-  z-index: 3; /* Above overlay */
+  z-index: 2; /* Above overlay */
   max-width: 900px; /* Limit width */
   width: 90%; /* Take 90% of parent width, up to max-width */
   padding: 3rem 2rem; /* Add internal padding - Adjust for frame thickness */
@@ -50,8 +55,8 @@
 }
 
 .logo {
-  height: 40px;
-  width: auto;
+  max-width: 50vw;
+  height: auto;
   display: inline-block;
 }
 
@@ -94,8 +99,8 @@
   }
 
 .logo {
-  height: 40px;
-  width: auto;
+  max-width: 60vw;
+  height: auto;
   display: inline-block;
 }
 


### PR DESCRIPTION
## Summary
- center hero video by positioning absolutely
- cap logo width via CSS module
- reference logo styles in hero component

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_68577a363e8883289a904d0c6db9ecb5