### PR TITLE
Add Spotify env verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ REACT_APP_SPOTIFY_REDIRECT_URI=http://localhost:3000/dashboard
 
 These values are read by the front-end to initiate the login process.
 
+
+For the backend, the `spotifyArtistFetcher` Lambda also requires `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `ARTIST_IDS` and `SPOTIFY_TABLE` environment variables. Verify and update them from CloudShell using:
+
+```bash
+SPOTIFY_CLIENT_ID=your_client_id \
+SPOTIFY_CLIENT_SECRET=your_client_secret \
+ARTIST_IDS=your_artist_ids \
+./automate-verify-spotify-env.sh
+```
+
 ## Catalog & Pitch API Setup
 
 The catalog browsing pages and pitch submission form expect API endpoints to be

--- a/automate-verify-spotify-env.sh
+++ b/automate-verify-spotify-env.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# automate-verify-spotify-env.sh
+# Verify Spotify-related environment variables for the spotifyArtistFetcher Lambda
+# and optionally update them if missing. Intended for AWS CloudShell.
+
+set -euo pipefail
+
+LAMBDA_NAME="${LAMBDA_NAME:-spotifyArtistFetcher}"
+REQUIRED_VARS=(SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET ARTIST_IDS SPOTIFY_TABLE)
+
+# Fetch current Lambda environment variables
+current=$(aws lambda get-function-configuration \
+  --function-name "$LAMBDA_NAME" \
+  --query 'Environment.Variables' --output json)
+
+# Track variables in an associative array
+declare -A env
+for key in $(echo "$current" | jq -r 'keys[]'); do
+  env[$key]=$(echo "$current" | jq -r --arg k "$key" '.[$k]')
+done
+
+missing=()
+for var in "${REQUIRED_VARS[@]}"; do
+  val="${env[$var]:-}"
+  if [[ -z "$val" || "$val" == "null" ]]; then
+    missing+=("$var")
+    echo "❌ $var not set"
+  else
+    echo "✅ $var present"
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Updating Lambda environment with provided values..."
+  for var in "${missing[@]}"; do
+    new_val="${!var:-}"
+    if [[ -z "$new_val" ]]; then
+      echo "Skipping $var – provide it as an environment variable to set it"
+    else
+      env[$var]="$new_val"
+    fi
+  done
+  env_json="{"
+  first=1
+  for k in "${!env[@]}"; do
+    [[ $first -eq 0 ]] && env_json+=","
+    first=0
+    env_json+="\"$k\":\"${env[$k]}\""
+  done
+  env_json+="}"
+  aws lambda update-function-configuration \
+    --function-name "$LAMBDA_NAME" \
+    --environment "Variables=$env_json" >/dev/null
+  echo "Lambda environment updated"
+else
+  echo "All required variables are set"
+fi


### PR DESCRIPTION
## Summary
- add `automate-verify-spotify-env.sh` to validate and update Lambda Spotify variables in AWS CloudShell
- document script usage in README

## Testing
- `npm ci`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6858955f8f44832894f01f39ab0dee43