### PR TITLE
Add Spotify auth handler and login URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ SHORTS_BUCKET_PARAM=/decoded/shortsBucket
 SHORTS_LAMBDA_PARAM=/decoded/shortsLambda
 POLLY_VOICE_PARAM=/decoded/pollyVoice
 REACT_APP_API_BASE=https://your-api-id.execute-api.region.amazonaws.com/prod/dashboard
+REACT_APP_COGNITO_CHECK_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/auth/check-artist
+REACT_APP_SPOTIFY_AUTH_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/spotify-auth
+REACT_APP_SPOTIFY_CLIENT_ID=your_client_id
+REACT_APP_SPOTIFY_REDIRECT_URI=http://localhost:3000/dashboard

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ opened in a browser.
 ## Spotify Login Setup
 
 The Artist Dashboard now uses Spotify's authorization flow. Create a Spotify
-application and add the client ID and redirect URI to your `.env` (based on `.env.example`):
+application and add the client ID, redirect URI, and the backend auth URL to your `.env` (based on `.env.example`):
 
 ```bash
 REACT_APP_SPOTIFY_CLIENT_ID=your_client_id
 REACT_APP_SPOTIFY_REDIRECT_URI=http://localhost:3000/dashboard
+REACT_APP_SPOTIFY_AUTH_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/spotify-auth
 ```
 
 These values are read by the front-end to initiate the login process.
@@ -107,6 +108,15 @@ PITCH_TARGET_EMAIL=ops@decodedmusic.com
 ```
 
 These URLs are outputs of the `decoded-genai-stack` CloudFormation stack.
+
+## Cognito Access Check
+
+The sign-in page posts the user's email to a backend endpoint which verifies the
+`artist` group membership in Cognito. Add the URL to your `.env`:
+
+```bash
+REACT_APP_COGNITO_CHECK_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/auth/check-artist
+```
 
 **Future Development:**
 

--- a/backend/lambda/cognitoCheck/index.js
+++ b/backend/lambda/cognitoCheck/index.js
@@ -1,0 +1,33 @@
+const { CognitoIdentityProviderClient, AdminListGroupsForUserCommand } = require('@aws-sdk/client-cognito-identity-provider');
+
+const REGION = process.env.AWS_REGION || 'eu-central-1';
+const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID || '5fxmkd';
+const ARTIST_GROUP = process.env.ARTIST_GROUP || 'artist';
+const client = new CognitoIdentityProviderClient({ region: REGION });
+
+exports.handler = async (event) => {
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const email = body.email;
+    if (!email) return response(400, { message: 'email required' });
+
+    const res = await client.send(new AdminListGroupsForUserCommand({
+      UserPoolId: USER_POOL_ID,
+      Username: email
+    }));
+    const groups = res.Groups || [];
+    const authorized = groups.some(g => g.GroupName === ARTIST_GROUP);
+    return response(200, { authorized });
+  } catch (err) {
+    console.error('cognito check error', err);
+    return response(500, { message: 'error' });
+  }
+};
+
+function response(statusCode, body) {
+  return {
+    statusCode,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify(body)
+  };
+}

--- a/backend/lambda/spotifyAuthHandler.js
+++ b/backend/lambda/spotifyAuthHandler.js
@@ -1,0 +1,60 @@
+const https = require("https");
+const querystring = require("querystring");
+
+const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
+const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
+const REDIRECT_URI = process.env.SPOTIFY_REDIRECT_URI;
+
+exports.handler = async (event) => {
+  const params = event.queryStringParameters || {};
+
+  if (!params.code) {
+    const authURL = `https://accounts.spotify.com/authorize?${querystring.stringify({
+      response_type: "code",
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      scope: "user-read-email",
+    })}`;
+    return {
+      statusCode: 302,
+      headers: { Location: authURL },
+    };
+  }
+
+  const body = querystring.stringify({
+    grant_type: "authorization_code",
+    code: params.code,
+    redirect_uri: REDIRECT_URI,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  });
+
+  const options = {
+    hostname: "accounts.spotify.com",
+    path: "/api/token",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Content-Length": body.length,
+    },
+  };
+
+  const tokenData = await new Promise((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      let data = "";
+      res.on("data", (chunk) => (data += chunk));
+      res.on("end", () => resolve(JSON.parse(data)));
+    });
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(tokenData),
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+    },
+  };
+};

--- a/docs/authentication-access-control.md
+++ b/docs/authentication-access-control.md
@@ -5,7 +5,19 @@ This document outlines how the Artist Dashboard handles user authentication and 
 ### Spotify OAuth 2.0 Flow
 - `GET /api/auth/spotify/login` – Redirects the user to Spotify's authorization endpoint.
 - `GET /api/auth/spotify/callback` – Exchanges the authorization code for an access token and stores the tokens in DynamoDB or Amazon Cognito.
+- `GET /api/spotify-auth` – Combined handler that redirects if no `code` is provided and exchanges the code for tokens otherwise.
+  Environment variables:
+  - `SPOTIFY_CLIENT_ID`
+  - `SPOTIFY_CLIENT_SECRET`
+  - `SPOTIFY_REDIRECT_URI`
 
 ### Cognito User Pools
 - The project uses an Amazon Cognito User Pool to manage logins. The current pool for **Rue de Vivre** is `5fxmkd`.
 - This setup can be expanded in the future to allow multiple artist accounts.
+
+### Artist Group Check Endpoint
+- `POST /api/auth/check-artist` – Body `{ "email": "user@example.com" }`.
+  Returns `{ "authorized": true }` if the user belongs to the `artist` group in the configured Cognito pool.
+  Environment variables:
+  - `COGNITO_USER_POOL_ID` – defaults to `5fxmkd`
+  - `ARTIST_GROUP` – defaults to `artist`

--- a/src/pages/ArtistDashboard.js
+++ b/src/pages/ArtistDashboard.js
@@ -3,7 +3,9 @@ import { DashboardAPI } from '../api/dashboard';
 import SpotifyModule from '../components/SpotifyModule';
 
 const CLIENT_ID = process.env.REACT_APP_SPOTIFY_CLIENT_ID;
-const REDIRECT_URI = process.env.REACT_APP_SPOTIFY_REDIRECT_URI || window.location.origin + '/dashboard';
+const REDIRECT_URI = process.env.REACT_APP_SPOTIFY_REDIRECT_URI ||
+  window.location.origin + '/dashboard';
+const AUTH_URL = process.env.REACT_APP_SPOTIFY_AUTH_URL;
 const SCOPES = ['user-read-email'];
 
 function buildAuthUrl() {
@@ -41,11 +43,12 @@ function ArtistDashboard() {
   const token = window.localStorage.getItem('spotify_token');
 
   if (!token) {
+    const loginHref = AUTH_URL || buildAuthUrl();
     return (
       <div style={{ padding: '2rem' }}>
         <h1>Artist Dashboard Login</h1>
         <p>Sign in with Spotify to continue.</p>
-        <a href={buildAuthUrl()} style={{ padding: '0.5rem 1rem', background: '#1DB954', color: '#fff', borderRadius: '4px' }}>
+        <a href={loginHref} style={{ padding: '0.5rem 1rem', background: '#1DB954', color: '#fff', borderRadius: '4px' }}>
           Log in with Spotify
         </a>
       </div>

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+const CHECK_URL = process.env.REACT_APP_COGNITO_CHECK_URL;
+
 export default function SignIn() {
   const [form, setForm] = useState({ email: "", password: "" });
   const [status, setStatus] = useState("");
@@ -8,10 +10,25 @@ export default function SignIn() {
     setForm({ ...form, [e.target.name]: e.target.value });
   }
 
-  function handleSubmit(e) {
+  async function handleSubmit(e) {
     e.preventDefault();
-    window.localStorage.setItem("demo_user", JSON.stringify(form));
-    setStatus("Signed in locally (no backend)");
+    setStatus("Checking access...");
+    try {
+      const res = await fetch(CHECK_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: form.email })
+      });
+      const data = await res.json();
+      if (data.authorized) {
+        window.location.href = "/dashboard";
+      } else {
+        setStatus("Access denied");
+      }
+    } catch (err) {
+      console.error("check error", err);
+      setStatus("Error validating user");
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- create Lambda handler for Spotify OAuth exchange
- fall back to backend auth URL when logging in to the dashboard
- document the Spotify auth endpoint in authentication guide
- include Spotify OAuth variables in `.env.example` and README

## Testing
- `./setup.sh`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6858278bd7008328bdf39f8bf332851c