### PR TITLE
Load Spotify credentials from Secrets Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@
 NEWS_API_KEY_SECRET=my/newsApiKey
 STRIPE_SECRET_KEY_SECRET=my/stripeSecret
 STRIPE_PUBLISHABLE_KEY=your_stripe_publishable
+# Spotify credentials secret containing JSON with client_id and client_secret
+SPOTIFY_CREDENTIALS_SECRET=my/spotifyCreds
+# Artist IDs to fetch, comma-separated
+ARTIST_IDS=your_artist_ids
+# DynamoDB table for Spotify stats
+SPOTIFY_TABLE=SpotifyArtistData
 # Deployment region
 AWS_REGION=eu-central-1
 # Choose your preferred model: meta.llama3-70b-instruct-v1:0 or anthropic.claude-3-sonnet-20240229-v1:0

--- a/README.md
+++ b/README.md
@@ -84,11 +84,10 @@ REACT_APP_SPOTIFY_REDIRECT_URI=http://localhost:3000/dashboard
 These values are read by the front-end to initiate the login process.
 
 
-For the backend, the `spotifyArtistFetcher` Lambda also requires `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `ARTIST_IDS` and `SPOTIFY_TABLE` environment variables. Verify and update them from CloudShell using:
+For the backend, the `spotifyArtistFetcher` Lambda expects `SPOTIFY_CREDENTIALS_SECRET`, `ARTIST_IDS` and `SPOTIFY_TABLE` environment variables. The secret should contain JSON like `{ "client_id": "...", "client_secret": "..." }`. Verify and update them from CloudShell using:
 
 ```bash
-SPOTIFY_CLIENT_ID=your_client_id \
-SPOTIFY_CLIENT_SECRET=your_client_secret \
+SPOTIFY_CREDENTIALS_SECRET=my/spotifyCreds \
 ARTIST_IDS=your_artist_ids \
 ./automate-verify-spotify-env.sh
 ```

--- a/automate-verify-spotify-env.sh
+++ b/automate-verify-spotify-env.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # automate-verify-spotify-env.sh
 # Verify Spotify-related environment variables for the spotifyArtistFetcher Lambda
-# and optionally update them if missing. Intended for AWS CloudShell.
+# and optionally update them if missing. Intended for AWS CloudShell. The Lambda
+# now expects SPOTIFY_CREDENTIALS_SECRET instead of separate ID/secret values.
 
 set -euo pipefail
 
 LAMBDA_NAME="${LAMBDA_NAME:-spotifyArtistFetcher}"
-REQUIRED_VARS=(SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET ARTIST_IDS SPOTIFY_TABLE)
+REQUIRED_VARS=(SPOTIFY_CREDENTIALS_SECRET ARTIST_IDS SPOTIFY_TABLE)
 
 # Fetch current Lambda environment variables
 current=$(aws lambda get-function-configuration \

--- a/docs/spotify-module.md
+++ b/docs/spotify-module.md
@@ -18,7 +18,7 @@ Partition key is `artist_id` with `week_start` as a sort key so historical snaps
 
 ## Weekly Fetch Lambda
 
-`spotifyArtistFetcher` runs every **Wednesday** via EventBridge. It authenticates using `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET`, pulls profile, top tracks and a sample of trending categories for each `ARTIST_IDS` entry and writes the data to `SpotifyArtistData`.
+`spotifyArtistFetcher` runs every **Wednesday** via EventBridge. It loads Spotify credentials from the secret named by `SPOTIFY_CREDENTIALS_SECRET`, pulls profile, top tracks and a sample of trending categories for each `ARTIST_IDS` entry and writes the data to `SpotifyArtistData`.
 
 ## Dashboard Endpoint
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",
     "@aws-sdk/client-lambda": "^3.830.0",
-    "@aws-sdk/client-s3": "^3.830.0"
+    "@aws-sdk/client-s3": "^3.830.0",
+    "@aws-sdk/client-secrets-manager": "^3.830.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- fetch Spotify creds using Secrets Manager in spotifyArtistFetcher Lambda
- document new `SPOTIFY_CREDENTIALS_SECRET` variable in README and Spotify module docs
- add Spotify example values to `.env.example`
- update helper script for verifying Spotify Lambda env
- add Secrets Manager client dependency

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68598e4c13248328ac074ea099c77f0f