### PR TITLE
Add rotating links and logging to Facebook poster

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,8 @@ Configure `INSTAGRAM_TOKEN` and `INSTAGRAM_USER_ID` in your `.env` along with
 `backend/lambda/facebookPoster` posts to one or more Facebook Pages using the
 Meta Graph API. Set `FACEBOOK_TOKEN` and a comma separated list of page IDs in
 `FACEBOOK_PAGE_IDS`. The function optionally uses Bedrock to generate the post
-content.
+content. Each post ends with a randomly chosen artist link (Apple Music,
+YouTube, or Spotify) and logs the posting progress for debugging.
 
 
 ## YouTube Shorts Automation


### PR DESCRIPTION
## Summary
- rotate Apple, YouTube, and Spotify links in Facebook posts
- log generated messages and posting progress
- document rotating link behavior in the README

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859c6efd58083288888919122bbfa62