### PR TITLE
Expose Industry Buzz page

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ Schedule this command to run daily (for example using `cron` or AWS EventBridge)
 The generated summary can be shared to social platforms via the
 [Threads Graph API](https://developers.facebook.com/docs/threads-api).
 
-The latest summary is displayed in `public/buzz.html`. This page uses Tailwind
-via CDN and fetches `industry_buzz.txt` to populate the bullet points when
-opened in a browser.
+The latest summary is displayed in the app at `/buzz`. This page fetches
+`industry_buzz.txt` and shows the bullet points when opened in a browser.
 
 ## Spotify Login Setup
 

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import About from "./pages/About";
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
+import BuzzPage from './pages/BuzzPage';
 import ArtistDashboard from './pages/ArtistDashboard';
 import MarketingHub from './pages/MarketingHub';
 import Accounting from './pages/Accounting';
@@ -16,6 +17,7 @@ function App() {
       <Route path="/about" element={<About />} />
       <Route path="/signin" element={<SignIn />} />
       <Route path="/signup" element={<SignUp />} />
+      <Route path="/buzz" element={<BuzzPage />} />
       <Route path="/" element={<LandingPage />} />
       <Route path="/dashboard" element={<ArtistDashboard />} />
       <Route path="/marketing" element={<MarketingHub />} />

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -24,6 +24,9 @@ export default function Footer() {
           <a href="/about" className="underline">
             About Us
           </a>
+          <a href="/buzz" className="underline">
+            Buzz
+          </a>
           <a
             href="/policies.html"
             target="_blank"

--- a/src/content/landingPage.json
+++ b/src/content/landingPage.json
@@ -4,7 +4,8 @@
     "navLinks": [
       { "href": "/dashboard", "text": "Artist Dashboard" },
       { "href": "/about", "text": "About" },
-      { "href": "/contact", "text": "Contact" }
+      { "href": "/contact", "text": "Contact" },
+      { "href": "/buzz", "text": "Buzz" }
     ],
     "signInButtonHref": "/signin",
     "signInButtonText": "Sign In",

--- a/src/pages/ArtistDashboard.js
+++ b/src/pages/ArtistDashboard.js
@@ -49,7 +49,7 @@ function ArtistDashboard() {
     return (
       <div style={{ padding: '2rem' }}>
         <h1>Artist Dashboard Login</h1>
-
+        <a href={loginHref} style={{ padding: '0.5rem 1rem', background: '#1db954', color: '#fff', borderRadius: '4px', display: 'inline-block', marginRight: '0.5rem' }}>
           Log in with Spotify
         </a>
         <a href="/signin" style={{ padding: '0.5rem 1rem', background: '#2563eb', color: '#fff', borderRadius: '4px' }}>

--- a/src/pages/BuzzPage.js
+++ b/src/pages/BuzzPage.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import PageLayout from '../layouts/PageLayout';
+
+function BuzzPage() {
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    fetch('/industry_buzz.txt')
+      .then(res => res.text())
+      .then(text => setContent(text.trim()))
+      .catch(() => setContent('No update available.'));
+  }, []);
+
+  const runDate = new Date().toISOString().split('T')[0];
+
+  return (
+    <PageLayout>
+      <section style={{ background: '#fff', color: '#1F2937', padding: '1rem' }}>
+        <div style={{ maxWidth: '28rem', margin: '0 auto' }}>
+          <header style={{ marginBottom: '1rem', textAlign: 'center' }}>
+            <h1 style={{ fontSize: '1.25rem', fontWeight: 'bold' }}>Industry Buzz</h1>
+            <p style={{ fontSize: '0.875rem', color: '#6B7280' }}>Buzz | Music Management Researcher</p>
+            <p style={{ fontSize: '0.75rem', color: '#9CA3AF' }}>Run date: {runDate}</p>
+          </header>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: '0.875rem' }}>{content}</pre>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}
+
+export default BuzzPage;


### PR DESCRIPTION
## Summary
- add new `/buzz` page that fetches the daily industry buzz summary
- link to the new page from the header and footer
- route `/buzz` in the app
- fix missing link markup in `ArtistDashboard`
- document the new page in the README

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6859cd24423c8328a2fc5c924a2df025