### PR TITLE
Add analytics API URL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ BEDROCK_MODEL_ID_PARAM=/decoded/bedrockModelId
 S3_BUCKET_PARAM=/decoded/s3Bucket
 REACT_APP_PITCH_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/pitch
 REACT_APP_CATALOG_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/catalog
+REACT_APP_ANALYTICS_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/analytics
 REACT_APP_SIGNUP_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/signup
 REACT_APP_CONTACT_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/contact
 REACT_APP_AUTH_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/auth

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ configured in your `.env` file:
 ```bash
 REACT_APP_PITCH_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/pitch
 REACT_APP_CATALOG_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/catalog
+REACT_APP_ANALYTICS_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/analytics
 REACT_APP_SIGNUP_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/signup
 REACT_APP_CONTACT_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/contact
 REACT_APP_AUTH_API_URL=https://your-api-id.execute-api.region.amazonaws.com/prod/auth

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,4 +1,6 @@
 const API_BASE = process.env.REACT_APP_API_BASE;
+const ANALYTICS_URL =
+  process.env.REACT_APP_ANALYTICS_API_URL || `${API_BASE}/analytics`;
 
 export const DashboardAPI = {
   getAccounting: (payload) =>
@@ -9,7 +11,7 @@ export const DashboardAPI = {
     }).then((res) => res.json()),
 
   getAnalytics: (payload) =>
-    fetch(`${API_BASE}/analytics`, {
+    fetch(ANALYTICS_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- allow overriding analytics endpoint via `REACT_APP_ANALYTICS_API_URL`
- document analytics API URL in README
- provide placeholder in `.env.example`

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6859dd508dec83288eab6f45cf246f6e