### PR TITLE
Fix linter warning

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-﻿import React, { useState, useEffect } from 'react';
+﻿import { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import LandingPage from './components/LandingPage';
 import Dashboard from './components/Dashboard';


### PR DESCRIPTION
## Summary
- remove unused `React` variable from App.js import

## Testing
- `npm run lint` *(fails: A config object is using the `env` key)*
- `npm test -- --watchAll=false` *(fails: Cannot find module './LandingPage.css')*

------
https://chatgpt.com/codex/tasks/task_b_686c39dbfa688328bf8ad6103d45f10b